### PR TITLE
csv-parser: fix use of uninitialized member `silent`

### DIFF
--- a/src/csv-parser.cc
+++ b/src/csv-parser.cc
@@ -26,7 +26,6 @@
 struct AbstractCsvParser::Private {
     const std::string      *pFileName   = nullptr;
     int                     lineno      = 0;
-    bool                    silent      = false;
     bool                    hasError    = false;
 };
 
@@ -70,7 +69,7 @@ void AbstractCsvParser::parseError(const std::string &msg)
 {
     assert(d->pFileName);
     d->hasError = true;
-    if (d->silent)
+    if (this->silent)
         return;
 
     std::cerr

--- a/src/csv-parser.hh
+++ b/src/csv-parser.hh
@@ -41,7 +41,7 @@ class AbstractCsvParser {
         virtual bool /* continue */ handleLine(const TStringList &) = 0;
         void parseError(const std::string &msg);
 
-        bool silent;
+        bool silent = false;
 
     private:
         struct Private;


### PR DESCRIPTION
There were two instances of the flag by mistake.  Detected by Coverity.