### PR TITLE
CI: make Packit use the same `%{version}.%{release}` as `make-srpm.sh`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,8 +13,10 @@ upstream_package_name: csdiff
 # downstream (Fedora) RPM package name
 downstream_package_name: csdiff
 
+release_suffix: ""
 actions:
     post-upstream-clone: ./make-srpm.sh --generate-spec
+    get-current-version: "sed -n 's|^Version: *||p' csdiff.spec"
 
 jobs:
     - &copr


### PR DESCRIPTION
We should be using the same versioning scheme so that we don't unintentionally break package upgrades.

Blocks: #56