### PR TITLE
packit: metadata section is no longer needed

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,20 +22,18 @@ jobs:
     - &copr
       job: copr_build
       trigger: pull_request
-      metadata:
-        targets:
-            - epel-all-aarch64
-            - epel-all-ppc64le
-            - epel-all-s390x
-            - epel-all-x86_64
-            - fedora-all-aarch64
-            - fedora-all-ppc64le
-            - fedora-all-s390x
-            - fedora-all-x86_64
+      targets:
+          - epel-all-aarch64
+          - epel-all-ppc64le
+          - epel-all-s390x
+          - epel-all-x86_64
+          - fedora-all-aarch64
+          - fedora-all-ppc64le
+          - fedora-all-s390x
+          - fedora-all-x86_64
 
     - <<: *copr
       trigger: commit
-      metadata:
-        owner: "@codescan"
-        project: "csdiff"
-        branch: main
+      owner: "@codescan"
+      project: "csdiff"
+      branch: main


### PR DESCRIPTION
We recently dropped the need for "metadata", now all configuration can happen on the job level.