### PR TITLE
Modernize spec file

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -167,6 +167,8 @@ make version.cc
 %ctest3
 
 %files
+%doc README
+%license COPYING
 %{_bindir}/csdiff
 %{_bindir}/csgrep
 %{_bindir}/cshtml
@@ -180,18 +182,17 @@ make version.cc
 %{_mandir}/man1/cslinker.1*
 %{_mandir}/man1/cssort.1*
 %{_mandir}/man1/cstrans-df-run.1*
-%doc COPYING README
 
 %if %{with python2}
 %files -n python2-%{name}
+%license COPYING
 %{python2_sitearch}/pycsdiff.so
-%doc COPYING
 %endif
 
 %if %{with python3}
 %files -n python3-%{name}
+%license COPYING
 %{python3_sitearch}/pycsdiff.so
-%doc COPYING
 %endif
 EOF
 

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -97,7 +97,7 @@ URL:        https://github.com/csutils/csdiff
 Source0:    https://github.com/csutils/csdiff/releases/download/%{name}-%{version}/%{name}-%{version}.tar.xz
 
 # the following upstream commit is needed to work with up2date csdiff/csgrep
-# https://github.com/kdudka/csmock/commit/48b09b3a
+# https://github.com/csutils/csmock/commit/48b09b3a
 Conflicts:  csmock-plugin-shellcheck <= 2.5
 
 BuildRequires: boost-devel

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -122,7 +122,7 @@ Summary:        Python interface to csdiff for Python 2
 BuildRequires:  boost-python2-devel
 %endif
 BuildRequires:  python2-devel
-%{?python_provide:%python_provide python2-%{name}}
+%py_provides    python2-%{name}
 
 %description -n python2-%{name}
 This package contains the Python 2 binding for the csdiff tool for comparing
@@ -143,7 +143,7 @@ BuildRequires:  epel-rpm-macros
 BuildRequires:  boost-python%{python3_pkgversion}-devel
 %endif
 BuildRequires:  python3-devel
-%{?python_provide:%python_provide python3-%{name}}
+%py_provides    python3-%{name}
 
 %description -n python3-%{name}
 This package contains the Python 3 binding for the csdiff tool for comparing

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -106,7 +106,7 @@ BuildRequires: gcc-c++
 BuildRequires: help2man
 BuildRequires: make
 
-%if 0%{?rhel} && 0%{?rhel} <= 8
+%if 0%{?rhel} && 0%{?rhel} < 9
 Provides: bundled(boost_nowide)
 %endif
 

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -118,9 +118,6 @@ defect lists using various filtering predicates.
 %if %{with python2}
 %package -n python2-%{name}
 Summary:        Python interface to csdiff for Python 2
-%if 0%{?fedora}
-BuildRequires:  boost-python2-devel
-%endif
 BuildRequires:  python2-devel
 %py_provides    python2-%{name}
 

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -147,7 +147,7 @@ code scan defect lists to find out added or fixed defects.
 %endif
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make version.cc

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -113,7 +113,7 @@ Provides: bundled(boost_nowide)
 %description
 This package contains the csdiff tool for comparing code scan defect lists in
 order to find out added or fixed defects, and the csgrep utility for filtering
-defect lists using various filtering predicates. 
+defect lists using various filtering predicates.
 
 %if %{with python2}
 %package -n python2-%{name}
@@ -133,7 +133,7 @@ code scan defect lists to find out added or fixed defects.
 %package -n python3-%{name}
 Summary:        Python interface to csdiff for Python 3
 
-# this packages redefines %%{python3_pkgversion} to 36 because there is
+# this package redefines %%{python3_pkgversion} to 36 because there is
 # no boost-python3-devel in epel-7 buildroot, only boost-python36-devel
 %if 0%{?rhel} == 7
 BuildRequires:  epel-rpm-macros

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -73,6 +73,10 @@ fi
 
 SPEC="./$PKG.spec"
 cat > "$SPEC" << EOF
+# disable in source builds on EPEL <9
+%undefine __cmake_in_source_build
+%undefine __cmake3_in_source_build
+
 # python2 is not available on RHEL > 7 and Fedora
 %if 0%{?rhel} > 7 || 0%{?fedora}
 %bcond_with python2
@@ -151,19 +155,16 @@ code scan defect lists to find out added or fixed defects.
 
 %build
 make version.cc
-mkdir -p %{_target_platform}
-cd %{_target_platform}
-%cmake3 .. -S.. -B. \\
+%cmake3                                    \\
     -DPYCSDIFF_PYTHON2=%{?with_python2:ON} \\
     -DPYCSDIFF_PYTHON3=%{?with_python3:ON}
-%make_build
+%cmake3_build
 
 %install
-%make_install -C %{_target_platform}
+%cmake3_install
 
 %check
-cd %{_target_platform}
-ctest3 %{?_smp_mflags} --output-on-failure
+%ctest3
 
 %files
 %{_bindir}/csdiff


### PR DESCRIPTION
* use `%autosetup` instead of `%setup -q`
* use `%cmake3{,_build,_install}` and `%ctest3` macros
* make links point to the upstream repository
* unify condition format across spec file
* use `%license` instead of `%doc` for `COPYING`
* use `%py_provides` instead of deprecated `%python_provide`
* fix typos
* remove dependency on `boost-python2-devel` for Fedora 