### PR TITLE
bash: use modern syntax for command substitution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,6 @@ src/version.cc:
 		cmd='basename $$(readlink -f .) | cut -f2 -d-'; \
 	fi \
 		&& printf "#include \"version.hh\"\nconst char *CS_VERSION = \"%s\";\n" \
-			"`eval "$$cmd"`" > $@.tmp \
+			"$$(eval "$$cmd")" > $@.tmp \
 		&& install -m0644 -C -v $@.tmp $@ \
 		&& rm -f $@.tmp

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -30,31 +30,31 @@ match() {
     grep "$@" > /dev/null
 }
 
-DST="`readlink -f "$PWD"`"
+DST="$(readlink -f "$PWD")"
 
-REPO="`git rev-parse --show-toplevel`"
+REPO="$(git rev-parse --show-toplevel)"
 test -d "$REPO" || die "not in a git repo"
 
-NV="`git describe --tags`"
+NV="$(git describe --tags)"
 echo "$NV" | match "^$PKG-" || die "release tag not found"
 
-VER="`echo "$NV" | sed "s/^$PKG-//"`"
+VER="$(echo "$NV" | sed "s/^$PKG-//")"
 
-TIMESTAMP="`git log --pretty="%cd" --date=iso -1 \
-    | tr -d ':-' | tr ' ' . | cut -d. -f 1,2`"
+TIMESTAMP="$(git log --pretty="%cd" --date=iso -1 \
+    | tr -d ':-' | tr ' ' . | cut -d. -f 1,2)"
 
-VER="`echo "$VER" | sed "s/-.*-/.$TIMESTAMP./"`"
+VER="$(echo "$VER" | sed "s/-.*-/.$TIMESTAMP./")"
 
-BRANCH="`git rev-parse --abbrev-ref HEAD`"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 test -n "$BRANCH" || die "failed to get current branch name"
 test "main" = "${BRANCH}" || VER="${VER}.${BRANCH//[\/-]/_}"
-test -z "`git diff HEAD`" || VER="${VER}.dirty"
+test -z "$(git diff HEAD)" || VER="${VER}.dirty"
 
 NV="${PKG}-${VER}"
 printf "\n%s: preparing a release of \033[1;32m%s\033[0m\n\n" "$SELF" "$NV"
 
 if [[ "$1" != "--generate-spec" ]]; then
-    TMP="`mktemp -d`"
+    TMP="$(mktemp -d)"
     trap "rm -rf '$TMP'" EXIT
     cd "$TMP" >/dev/null || die "mktemp failed"
 

--- a/tests/cssort/sync-diff.sh
+++ b/tests/cssort/sync-diff.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-export CSSORT="`readlink -f ../../csdiff_build/src/cssort`"
+export CSSORT="$(readlink -f ../../csdiff_build/src/cssort)"
 
 for dir in cssort*/; do (
     cd $dir || exit $?
     for input in ??-input.err; do
-        bare_input=`basename $input -input.err`
+        bare_input=$(basename $input -input.err)
         set -x
         "$CSSORT" --key=checker ${input} 2>/dev/null > ${bare_input}-by-checker.err
         "$CSSORT" --key=path    ${input} 2>/dev/null > ${bare_input}-by-path.err


### PR DESCRIPTION
Replace `` `cmd` `` with `$(cmd)`.