### PR TITLE
Update man pages

### DIFF
--- a/doc/csdiff.h2m
+++ b/doc/csdiff.h2m
@@ -3,7 +3,7 @@ csdiff - take two lists of defects and output either added or fixed ones
 
 [OPTIONS]
 The \fB\-\-filter\-file\fR option takes a list of JSON files in the following
-format.  Missing replace entry is equal to replace : "".
+format.  Missing replace entry is equal to "replace" : "".
 
 .RS 4
 .nf

--- a/doc/csgrep.h2m
+++ b/doc/csgrep.h2m
@@ -35,10 +35,10 @@ libhsm.c:1210: var_deref_op: Dereferencing null pointer key_handles.
 .fi
 
 In the above example, FORWARD_NULL is the
-.B checker
-, assign_zero and var_deref_op are
-.B events
-, where var_deref_op is the key event and
+.BR checker ,
+assign_zero and var_deref_op are
+.BR events ,
+where var_deref_op is the key event and
 "Dereferencing null pointer key_handles." is the
 .B message
 associated with the key event.

--- a/doc/csgrep.h2m
+++ b/doc/csgrep.h2m
@@ -66,5 +66,8 @@ associated with the key event.
 .B json
 - print matched defects in a JSON format
 
+.B sarif
+- print matched defects in a SARIF format
+
 .B stat
 - print overall statistics of the matched defects in given error files

--- a/doc/csgrep.h2m
+++ b/doc/csgrep.h2m
@@ -3,7 +3,7 @@ csgrep - filter the list of defects by the specified regex-based predicates
 
 [OPTIONS]
 The \fB\-\-filter\-file\fR option takes a list of JSON files in the following
-format.  Missing replace entry is equal to replace : "".
+format.  Missing replace entry is equal to "replace" : "".
 
 .RS 4
 .nf


### PR DESCRIPTION
* document csgrep's `--mode=sarif` option
* fix example syntax with empty `replace` key and cs{diff,grep}
* do not print spaces between bold text and punctuation 