### PR TITLE
Run `coverity` workflow only on primary repository

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   coverity:
+    if: github.repository == 'csutils/csdiff'
     name: Coverity Scan
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Similar to: https://github.com/csutils/cswrap/pull/32