### PR TITLE
CI: drop Ubuntu 18.04 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang++, g++]
-        version: [18.04, 20.04, 22.04]
+        version: [20.04, 22.04]
 
     runs-on: ubuntu-${{ matrix.version }}
     env:


### PR DESCRIPTION
They are deprecated according to the GitHub Blog [1] and will be removed by
the end of November.

[1] https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/