### PR TITLE
cstrans-df-run: simplify the code using C++11 extensions

### DIFF
--- a/src/cstrans-df-run.cc
+++ b/src/cstrans-df-run.cc
@@ -267,7 +267,7 @@ bool transformInPlace(DockerFileTransformer &dft, const std::string &fileName)
     using namespace boost::filesystem;
 
     // open input file and temporary output file
-    std::fstream fin(fileName.c_str(), std::ios::in);
+    std::ifstream fin(fileName);
     if (!fin) {
         printOpenError("failed to open input file", fileName);
         return false;
@@ -275,10 +275,9 @@ bool transformInPlace(DockerFileTransformer &dft, const std::string &fileName)
 
     const path tmpFilePath = unique_path();
     const std::string tmpFileName = tmpFilePath.native();
-    std::fstream fout(tmpFileName.c_str(), std::ios::out);
+    std::ofstream fout(tmpFileName);
     if (!fout) {
         printOpenError("failed to create temporary file", tmpFileName);
-        fin.close();
         return false;
     }
 


### PR DESCRIPTION
We can use `std::ifstream` and `std::ofstream` to simplify construction of the stream objects.  And we do not need to close the streams when they are going to be destroyed (and hence automatically closed).