### PR TITLE
abstract-tree: let decoder iterate over tree nodes on its own

### DIFF
--- a/src/abstract-tree.hh
+++ b/src/abstract-tree.hh
@@ -43,16 +43,33 @@ class AbstractTreeDecoder {
         }
 
         /// locate the list of defects within the inner document format
-        virtual void readRoot(
-                const pt::ptree       **pDefList,
-                const pt::ptree        *root)
+        virtual void readRoot(const pt::ptree *root)
         {
-            *pDefList = root;
+            defList_ = root;
+            defIter_ = root->begin();
         }
 
-        /// read the given ptree node, decode, and store the result into def
-        virtual bool readNode(Defect *def, pt::ptree::const_iterator defIter)
-            = 0;
+        /// read the current node, decode into def, and move to the next one
+        virtual bool readNode(Defect *def) = 0;
+
+    protected:
+        const pt::ptree                *defList_ = nullptr;
+        pt::ptree::const_iterator       defIter_;
+
+        virtual const pt::ptree* nextNode()
+        {
+            if (!defList_)
+                // failed initialization
+                return nullptr;
+
+            if (defList_->end() == defIter_)
+                // EOF
+                return nullptr;
+
+            // move the iterator after we get the current position
+            const pt::ptree::const_iterator itNow = defIter_++;
+            return &itNow->second;
+        }
 };
 
 /// abstraction for higher-level encoders for various tree-based file formats

--- a/src/json-parser.hh
+++ b/src/json-parser.hh
@@ -36,11 +36,8 @@ class JsonParser: public AbstractParser {
         }
 
     private:
-        JsonParser(const Parser &);
-        JsonParser& operator=(const Parser &);
-
         struct Private;
-        Private *d;
+        std::unique_ptr<Private> d;
 };
 
 #endif /* H_GUARD_JSON_PARSER_H */

--- a/src/xml-parser.cc
+++ b/src/xml-parser.cc
@@ -282,8 +282,10 @@ bool ValgrindTreeDecoder::readNode(Defect *pDef, pt::ptree::const_iterator defIt
 }
 
 struct XmlParser::Private {
+    using TDecoderPtr = std::unique_ptr<AbstractTreeDecoder>;
+
     InStream                       &input;
-    AbstractTreeDecoder            *decoder = nullptr;
+    TDecoderPtr                     decoder;
     pt::ptree                       root;
     const pt::ptree                *defList = nullptr;
     pt::ptree::const_iterator       defIter = root.end();
@@ -291,11 +293,6 @@ struct XmlParser::Private {
     Private(InStream &input):
         input(input)
     {
-    }
-
-    ~Private()
-    {
-        delete this->decoder;
     }
 };
 
@@ -310,7 +307,7 @@ XmlParser::XmlParser(InStream &input):
         pt::ptree *node = nullptr;
         if (findChildOf(&node, d->root, "valgrindoutput"))
             // valgrind XML format
-            d->decoder = new ValgrindTreeDecoder;
+            d->decoder.reset(new ValgrindTreeDecoder);
         else
             throw pt::ptree_error("unknown XML format");
 
@@ -328,10 +325,7 @@ XmlParser::XmlParser(InStream &input):
     }
 }
 
-XmlParser::~XmlParser()
-{
-    delete d;
-}
+XmlParser::~XmlParser() = default;
 
 bool XmlParser::hasError() const
 {

--- a/src/xml-parser.hh
+++ b/src/xml-parser.hh
@@ -31,11 +31,8 @@ class XmlParser: public AbstractParser {
         bool hasError() const override;
 
     private:
-        XmlParser(const Parser &);
-        XmlParser& operator=(const Parser &);
-
         struct Private;
-        Private *d;
+        std::unique_ptr<Private> d;
 };
 
 #endif /* H_GUARD_XML_PARSER_H */


### PR DESCRIPTION
Before this change, iteration over tree nodes was handled externally but it only worked when all the visited nodes were at the same level.

In order to handle the JSON output format produced by OWASP ZAP, we need to iterate over two levels:
1. The top-level "site" array.
2. The nested "alerts" array.

To handle tree formats like this, it works better when the decoder iterates over the nodes on its own, each time the `readNode()` method is called.

No change in behavior is intended by this commit.

Related: https://github.com/csutils/csdiff/issues/90