### PR TITLE
CI: use update_release instead of release_suffix

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,7 +15,7 @@ downstream_package_name: csdiff
 
 srpm_build_deps: [rpm-build]
 
-release_suffix: ""
+update_release: false
 actions:
     post-upstream-clone: ./make-srpm.sh --generate-spec
     get-current-version: "sed -n 's|^Version: *||p' csdiff.spec"


### PR DESCRIPTION
[update_release](https://packit.dev/docs/configuration/#update_release) is a new way how to tell Packit to not update the release string