### PR TITLE
parser-json-simple: eliminate `-Wdangling-reference` false positive

### DIFF
--- a/src/lib/parser-json-simple.cc
+++ b/src/lib/parser-json-simple.cc
@@ -19,6 +19,7 @@
 
 #include "parser-json-simple.hh"
 
+#include "abstract-tree.hh"         // for findChildOf()
 #include "parser-cov.hh"            // for KeyEventDigger
 
 #include <set>
@@ -106,12 +107,10 @@ void SimpleTreeDecoder::readScanProps(
         TScanProps                 *pDst,
         const pt::ptree            *root)
 {
-    const pt::ptree emp;
-    const pt::ptree &scanNode =
-        root->get_child_optional("scan").get_value_or(emp);
-
-    for (const pt::ptree::value_type &item : scanNode)
-        (*pDst)[item.first] = item.second.data();
+    const pt::ptree *scanNode;
+    if (findChildOf(&scanNode, *root, "scan"))
+        for (const pt::ptree::value_type &item : *scanNode)
+            (*pDst)[item.first] = item.second.data();
 }
 
 bool SimpleTreeDecoder::readNode(Defect *def)


### PR DESCRIPTION
... with gcc-13.0.1-0.2.fc38.x86_64:
```
src/lib/parser-json-simple.cc: In member function ‘virtual void SimpleTreeDecoder::readScanProps(TScanProps*, const boost::property_tree::ptree*)’:
src/lib/parser-json-simple.cc:110:22: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  110 |     const pt::ptree &scanNode =
      |                      ^~~~~~~~
src/lib/parser-json-simple.cc:111:54: note: the temporary was destroyed at the end of the full expression ‘boost::property_tree::basic_ptree<Key, Data, KeyCompare>::get_child_optional(const path_type&) const [with Key = std::__cxx11::basic_string<char>; Data = std::__cxx11::basic_string<char>; KeyCompare = std::less<std::__cxx11::basic_string<char> >; path_type = boost::property_tree::string_path<std::__cxx11::basic_string<char>, boost::property_tree::id_translator<std::__cxx11::basic_string<char> > >](boost::property_tree::string_path<std::__cxx11::basic_string<char>, boost::property_tree::id_translator<std::__cxx11::basic_string<char> > >(((const char*)"scan"), ((int)'.'), (boost::property_tree::id_translator<std::__cxx11::basic_string<char> >(), boost::property_tree::id_translator<std::__cxx11::basic_string<char> >()))).boost::optional<const boost::property_tree::basic_ptree<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&>::get_value_or<const boost::property_tree::basic_ptree<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&>(emp, 1)’
  111 |         root->get_child_optional("scan").get_value_or(emp);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```