### PR TITLE
Replace Boost.Regex with the standard library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,6 @@ endif()
 find_package(Boost REQUIRED
     COMPONENTS filesystem
                program_options
-               regex
                system
     OPTIONAL_COMPONENTS json
                         nowide)
@@ -56,9 +55,7 @@ add_subdirectory(lib)
 include_directories(lib)
 
 # link cslib.a and boost libraries
-link_libraries(cs
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_REGEX_LIBRARY})
+link_libraries(cs ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 # the list of executables
 add_executable(csdiff       csdiff.cc)

--- a/src/csdiff.cc
+++ b/src/csdiff.cc
@@ -120,10 +120,10 @@ int main(int argc, char *argv[])
     // there are probably better solutions for this (Custom Validations)
     if (vm.count("file-rename")) {
         const TStringList &substList = vm["file-rename"].as<TStringList>();
-        boost::smatch sm;
+        std::smatch sm;
         const RE reSubst("([^,]+),(.*)");
         for (const string &subst : substList) {
-            if (!boost::regex_match(subst, sm, reSubst)) {
+            if (!std::regex_match(subst, sm, reSubst)) {
                 std::cerr << "bad substitution format: " << subst
                     << std::endl << "use: -s OLD,NEW" << std::endl;
                 return 1;

--- a/src/csgrep.cc
+++ b/src/csgrep.cc
@@ -187,7 +187,7 @@ class MsgPredicate: public IPredicate {
 
         bool matchDef(const Defect &def) const override {
             for (const DefEvent &evt : def.events) {
-                if (boost::regex_search(evt.msg, re_))
+                if (std::regex_search(evt.msg, re_))
                     return true;
             }
 
@@ -211,7 +211,7 @@ class ToolPredicate: public IPredicate {
             Defect def = defOrig;
             digger_.inferToolFromChecker(&def, /* onlyIfMissing */ true);
 
-            return boost::regex_search(def.tool, re_);
+            return std::regex_search(def.tool, re_);
         }
 };
 
@@ -227,7 +227,7 @@ class KeyEventPredicate: public IPredicate {
 
         bool matchDef(const Defect &def) const override {
             const DefEvent &keyEvent = def.events[def.keyEventIdx];
-            return boost::regex_search(keyEvent.event, re_);
+            return std::regex_search(keyEvent.event, re_);
         }
 };
 
@@ -243,7 +243,7 @@ class ErrorPredicate: public IPredicate {
 
         bool matchDef(const Defect &def) const override {
             const DefEvent &evt = def.events[def.keyEventIdx];
-            return boost::regex_search(evt.msg, re_);
+            return std::regex_search(evt.msg, re_);
         }
 };
 
@@ -259,7 +259,7 @@ class PathPredicate: public IPredicate {
 
         bool matchDef(const Defect &def) const override {
             const DefEvent &evt = def.events[def.keyEventIdx];
-            return boost::regex_search(evt.fileName, re_);
+            return std::regex_search(evt.fileName, re_);
         }
 };
 
@@ -274,7 +274,7 @@ class CheckerPredicate: public IPredicate {
         }
 
         bool matchDef(const Defect &def) const override {
-            return boost::regex_search(def.checker, re_);
+            return std::regex_search(def.checker, re_);
         }
 };
 
@@ -289,7 +289,7 @@ class AnnotPredicate: public IPredicate {
         }
 
         bool matchDef(const Defect &def) const override {
-            return boost::regex_search(def.annotation, re_);
+            return std::regex_search(def.annotation, re_);
         }
 };
 
@@ -328,7 +328,7 @@ class SrcAnnotPredicate: public IPredicate {
                 goto fail;
             }
 
-            matched = boost::regex_search(line, re_);
+            matched = std::regex_search(line, re_);
 fail:
             fstr.close();
             return matched;
@@ -552,7 +552,7 @@ template <class TPred>
 bool appendPredIfNeeded(
         PredicateFilter                                 *pf,
         const po::variables_map                         &vm,
-        boost::regex_constants::syntax_option_type      flags,
+        std::regex_constants::syntax_option_type         flags,
         const char                                      *key)
 {
     if (!vm.count(key))
@@ -602,9 +602,9 @@ bool chainFilters(
     *pEng = pf;
 
     // common matching flags
-    boost::regex_constants::syntax_option_type flags = 0;
+    std::regex_constants::syntax_option_type flags{};
     if (vm.count("ignore-case"))
-        flags |= boost::regex_constants::icase;
+        flags |= std::regex_constants::icase;
 
     if (vm.count("invert-match"))
         pf->setInvertMatch();

--- a/src/cshtml.cc
+++ b/src/cshtml.cc
@@ -38,14 +38,14 @@ std::string titleFromFileName(const std::string &fileName)
         return "";
 
     const RE reNoVer("^(.*/)?[^/0-9]*$");
-    if (boost::regex_match(fileName, reNoVer))
+    if (std::regex_match(fileName, reNoVer))
         // no version information -> bailing out
         return "";
 
     const RE reTitle("^(?:.*/)?([^/]*)\\.(?:err|js)$");
 
-    boost::smatch sm;
-    if (!boost::regex_match(fileName, sm, reTitle))
+    std::smatch sm;
+    if (!std::regex_match(fileName, sm, reTitle))
         return "";
 
     return sm[/* title */ 1];

--- a/src/cssort.cc
+++ b/src/cssort.cc
@@ -111,10 +111,10 @@ bool operator<(const DefByChecker &a, const DefByChecker &b)
         // sort ShellCheck warnings by the [SC1234] suffixes
         const RE reCode("^.* \\[SC([0-9]+)\\]$");
         std::string aCode, bCode;
-        boost::smatch sm;
-        if (boost::regex_match(ea.msg, sm, reCode))
+        std::smatch sm;
+        if (std::regex_match(ea.msg, sm, reCode))
             aCode = sm[1];
-        if (boost::regex_match(eb.msg, sm, reCode))
+        if (std::regex_match(eb.msg, sm, reCode))
             bCode = sm[1];
         if (aCode < bCode)
             return true;

--- a/src/cstrans-df-run.cc
+++ b/src/cstrans-df-run.cc
@@ -169,12 +169,12 @@ bool DockerFileTransformer::transformRunLine(std::string *pRunLine)
     TStringList execList = prefixCmd_;
 
     try {
-        boost::smatch sm;
-        if (boost::regex_match(*pRunLine, sm, reLineRunExec_))
+        std::smatch sm;
+        if (std::regex_match(*pRunLine, sm, reLineRunExec_))
             // RUN ["cmd", "arg1", "arg2", ...]
             appendExecArgs(&execList, sm[1]);
 
-        else if (boost::regex_match(*pRunLine, sm, reLineRun_))
+        else if (std::regex_match(*pRunLine, sm, reLineRun_))
             // RUN arbitrary shell code...
             appendShellExec(&execList, sm[1]);
 
@@ -215,18 +215,18 @@ bool DockerFileTransformer::transform(std::istream &in, std::ostream &out)
 
         if (readingRunLine) {
             // check for comment because it does not need to end with back-slash
-            if (boost::regex_match(line, reComment_))
+            if (std::regex_match(line, reComment_))
                 continue;
         }
-        else if (!boost::regex_match(line, reLineRun_)) {
+        else if (!std::regex_match(line, reLineRun_)) {
             // pass unrelated contents of Dockerfile unchanged
             out << line << std::endl;
             continue;
         }
 
         // check for line ending with back-slash (multi-line RUN)
-        boost::smatch sm;
-        const bool lineCont = boost::regex_match(line, sm, reLineCont_);
+        std::smatch sm;
+        const bool lineCont = std::regex_match(line, sm, reLineCont_);
         if (lineCont)
             line = sm[1];
 

--- a/src/lib/parser-common.cc
+++ b/src/lib/parser-common.cc
@@ -86,8 +86,8 @@ void ImpliedAttrDigger::inferToolFromChecker(
         // tool already assigned
         return;
 
-    boost::smatch sm;
-    if (boost::regex_match(pDef->checker, sm, d->reToolWarning)) {
+    std::smatch sm;
+    if (std::regex_match(pDef->checker, sm, d->reToolWarning)) {
         // extract tool="gcc-analyzer" out of checker="GCC_ANALYZER_WARNING"
         std::string tool = sm[/* tool */ 1];
         boost::algorithm::to_lower(tool);

--- a/src/lib/parser-cov.cc
+++ b/src/lib/parser-cov.cc
@@ -72,7 +72,7 @@ bool LineReader::getLine(std::string *pDst)
         return false;
 
     std::string nextLine;
-    while (boost::regex_search(line, reTrailLoc_)
+    while (std::regex_search(line, reTrailLoc_)
             && this->getLinePriv(&nextLine))
     {
         // merge the current line with the next line
@@ -81,7 +81,7 @@ bool LineReader::getLine(std::string *pDst)
     }
 
     // remove the "path:" prefix if matched
-    *pDst = boost::regex_replace(line, rePathPref_, "");
+    *pDst = std::regex_replace(line, rePathPref_, "");
 
     return true;
 }
@@ -161,25 +161,25 @@ EToken ErrFileLexer::readNext()
     if (!lineReader_.getLine(&line))
         return T_NULL;
 
-    if (boost::regex_match(line, reEmpty_))
+    if (std::regex_match(line, reEmpty_))
         return T_EMPTY;
 
-    boost::smatch sm;
+    std::smatch sm;
 
-    if (boost::regex_match(line, sm, reChecker_)) {
+    if (std::regex_match(line, sm, reChecker_)) {
         def_ = Defect(sm[/* checker */ 1]);
         def_.annotation = sm[/* annotation */ 2];
         return T_CHECKER;
     }
 
-    if (boost::regex_match(line, sm, reComment_)) {
+    if (std::regex_match(line, sm, reComment_)) {
         evt_ = DefEvent();
         evt_.event  = sm[/* #     */ 1];
         evt_.msg    = sm[/* msg   */ 2];
         return T_COMMENT;
     }
 
-    if (!boost::regex_match(line, sm, reEvent_)) {
+    if (!std::regex_match(line, sm, reEvent_)) {
         evt_.msg = line;
         return T_UNKNOWN;
     }
@@ -215,8 +215,8 @@ struct KeyEventDigger::Private {
 const std::string KeyEventDigger::Private::stripEvtName(const std::string &evt)
     const
 {
-    boost::smatch sm;
-    if (boost::regex_match(evt, sm, this->reEvtSuffix))
+    std::smatch sm;
+    if (std::regex_match(evt, sm, this->reEvtSuffix))
         return sm[/* bare evt */ 1];
 
     // no match
@@ -412,8 +412,8 @@ class AnnotHandler {
 
 void AnnotHandler::handleDef(Defect *pDef)
 {
-    boost::smatch sm;
-    if (boost::regex_match(pDef->annotation, sm, reCweAnnot_)) {
+    std::smatch sm;
+    if (std::regex_match(pDef->annotation, sm, reCweAnnot_)) {
         pDef->cwe = parse_int(sm[/* cwe */ 1]);
         pDef->annotation.clear();
     }

--- a/src/lib/parser-gcc.cc
+++ b/src/lib/parser-gcc.cc
@@ -320,8 +320,8 @@ bool MultilineConcatenator::tryMerge(DefEvent *pEvt)
     if (smBase[/* -W suffix */ 2] != smExtra[/* -W suffix */ 2])
         return false;
 
-    assert(!smExtra[/* msg */ 1].str().empty());
-    const char *gap = (' ' == *smExtra[/* msg */ 1].str().begin()) ? "" : " ";
+    assert(!smExtra.str(/* msg */ 1).empty());
+    const char *gap = (' ' == smExtra.str(/* msg */ 1).front()) ? "" : " ";
 
     // concatenate both messages together
     pEvt->msg = smBase.str(/* msg */ 1) + gap

--- a/src/lib/parser-json-sarif.cc
+++ b/src/lib/parser-json-sarif.cc
@@ -70,8 +70,8 @@ void SarifTreeDecoder::Private::updateCweMap(const pt::ptree *driverNode)
             continue;
 
         const std::string cweStr = cweList->begin()->second.data();
-        boost::smatch sm;
-        if (!boost::regex_match(cweStr, sm, this->reCwe))
+        std::smatch sm;
+        if (!std::regex_match(cweStr, sm, this->reCwe))
             // unable to parse cwe
             continue;
 
@@ -134,8 +134,8 @@ void SarifTreeDecoder::readScanProps(
         // GCC
         d->singleChecker = "COMPILER_WARNING";
 
-        boost::smatch sm;
-        if (boost::regex_match(version, sm, d->reVersion))
+        std::smatch sm;
+        if (std::regex_match(version, sm, d->reVersion))
             (*pDst)["analyzer-version-gcc"] = sm[/* version */ 1];
     }
 }
@@ -316,8 +316,8 @@ bool SarifTreeDecoder::readNode(Defect *def)
     // read "rule" that triggered the report
     const auto rule = valueOf<std::string>(defNode, "ruleId");
     if (!rule.empty()) {
-        boost::smatch sm;
-        if (boost::regex_match(rule, sm, d->reRuleId)) {
+        std::smatch sm;
+        if (std::regex_match(rule, sm, d->reRuleId)) {
             // csdiff format
             def->checker    = sm[/* checker  */ 1];
             keyEvent.event  = sm[/* keyEvent */ 2];

--- a/src/lib/regex.hh
+++ b/src/lib/regex.hh
@@ -20,8 +20,8 @@
 #ifndef H_GUARD_REGEX_H
 #define H_GUARD_REGEX_H
 
-#include <boost/regex.hpp>
+#include <regex>
 
-typedef boost::regex RE;
+using RE = std::regex;
 
 #endif /* H_GUARD_REGEX_H */

--- a/src/lib/writer-html.cc
+++ b/src/lib/writer-html.cc
@@ -101,8 +101,8 @@ std::string digTitle(const TScanProps &props) {
         const std::string &args = it->second;
         const RE reSrpm("^.*[ /']([^ /']*)\\.src\\.rpm.*$");
 
-        boost::smatch sm;
-        if (!boost::regex_match(args, sm, reSrpm))
+        std::smatch sm;
+        if (!std::regex_match(args, sm, reSrpm))
             return "";
 
         title = sm[/* NVR */ 1];
@@ -190,10 +190,10 @@ void writeScanProps(std::ostream &str, const TScanProps &props) {
 void linkifyShellCheckMsg(std::string *pMsg)
 {
     static const RE reShellCheckMsg("(\\[)?SC([0-9]+)(\\])?$");
-    *pMsg = boost::regex_replace(*pMsg, reShellCheckMsg,
-            "<a href=\"https://github.com/koalaman/shellcheck/wiki/SC\\2\""
-            " title=\"description of ShellCheck's checker SC\\2\">"
-            "\\1SC\\2\\3</a>");
+    *pMsg = std::regex_replace(*pMsg, reShellCheckMsg,
+            "<a href=\"https://github.com/koalaman/shellcheck/wiki/SC$2\""
+            " title=\"description of ShellCheck's checker SC$2\">"
+            "$1SC$2$3</a>");
 }
 
 void printCweLink(std::ostream &str, const int cwe, const std::string &cweName)
@@ -438,7 +438,7 @@ void HtmlWriter::Private::writeNewDefWarning(const Defect &def)
         // not lookup set
         return;
 
-    if (boost::regex_match(def.checker, this->checkerIgnRegex))
+    if (std::regex_match(def.checker, this->checkerIgnRegex))
         // user requested to ignore this checker for lookup
         return;
 
@@ -525,9 +525,9 @@ void HtmlWriter::handleDef(const Defect &def)
         else {
             d->str << " ";
 
-            boost::smatch sm;
+            std::smatch sm;
             const std::string &evtName = evt.event;
-            if (boost::regex_match(evtName, sm, d->reEvent)) {
+            if (std::regex_match(evtName, sm, d->reEvent)) {
                 std::string msgId = HtmlLib::escapeTextInline(sm[/* id */ 2]);
                 if (def.checker == "SHELLCHECK_WARNING")
                     linkifyShellCheckMsg(&msgId);

--- a/src/lib/writer-json-sarif.cc
+++ b/src/lib/writer-json-sarif.cc
@@ -270,9 +270,9 @@ void SarifTreeEncoder::appendDef(const Defect &def)
     result["ruleId"] = ruleId;
 
     if (def.checker == "SHELLCHECK_WARNING") {
-        boost::smatch sm;
+        std::smatch sm;
         static const RE reShellCheckMsg("(\\[)?(SC[0-9]+)(\\])?$");
-        boost::regex_search(keyEvt.event, sm, reShellCheckMsg);
+        std::regex_search(keyEvt.event, sm, reShellCheckMsg);
 
         // update ShellCheck rule map
         shellCheckMap_[ruleId] = sm[2];

--- a/src/lib/writer.cc
+++ b/src/lib/writer.cc
@@ -135,11 +135,11 @@ CtxEventDetector::~CtxEventDetector() = default;
 bool CtxEventDetector::isAnyCtxLine(const DefEvent &evt) const
 {
     return (evt.event == "#")
-        && boost::regex_match(evt.msg, d->reAnyCtxLine);
+        && std::regex_match(evt.msg, d->reAnyCtxLine);
 }
 
 bool CtxEventDetector::isKeyCtxLine(const DefEvent &evt) const
 {
     return (evt.event == "#")
-        && boost::regex_match(evt.msg, d->reKeyCtxLine);
+        && std::regex_match(evt.msg, d->reKeyCtxLine);
 }


### PR DESCRIPTION
We removed the hard dependency on Boost.Regex due to the usage of regex streams when we switched to Boost.JSON in #105.  Let's use what the standard library provides instead.