### PR TITLE
csgrep --warning-rate-limit: fix msg of the note event

### DIFF
--- a/tests/csgrep/0110-warning-rate-limit-stdout.txt
+++ b/tests/csgrep/0110-warning-rate-limit-stdout.txt
@@ -1892,7 +1892,7 @@
                     "line": 3,
                     "column": 8,
                     "event": "note",
-                    "message": "99 occurrences of error[too-many] were discarded because of this",
+                    "message": "99 occurrences of note[SC2086] were discarded because of this",
                     "verbosity_level": 1
                 }
             ]
@@ -1917,7 +1917,7 @@
                     "line": 128,
                     "column": 37,
                     "event": "note",
-                    "message": "13 occurrences of error[too-many] were discarded because of this",
+                    "message": "13 occurrences of warning[SC2207] were discarded because of this",
                     "verbosity_level": 1
                 }
             ]

--- a/tests/csgrep/sync.sh
+++ b/tests/csgrep/sync.sh
@@ -2,7 +2,7 @@
 set -exo pipefail
 
 # set path to project root
-PROJECT_ROOT="../../"
+PROJECT_ROOT="../.."
 
 # import ${JSFILTER_CMD}
 . ../test-lib.sh


### PR DESCRIPTION
The code used a string that was already overwritten for the error event.