### PR TITLE
csgprep --ignore-parser-warnings: parser warnings do not affect exit code

### DIFF
--- a/src/csgrep.cc
+++ b/src/csgrep.cc
@@ -562,6 +562,7 @@ int main(int argc, char *argv[])
             ("prepend-path-prefix", po::value<string>(),        "string prefix to prepend to relative paths (applied after all filters)")
 
             ("ignore-case,i",                                   "ignore case when matching regular expressions")
+            ("ignore-parser-warnings",                          "if enabled, parser warnings about the input files do not affect exit code")
             ("invert-match,v",                                  "select defects that do not match the selected criteria")
             ("invert-regex,n",                                  "invert regular expressions in all predicates")
             ("filter-file,f",       po::value<TStringList>(),   "read custom filtering rules from a file in JSON format");
@@ -663,6 +664,9 @@ int main(int argc, char *argv[])
             || !chainDecoratorIntArg<CtxEmbedder>(&eng, vm, "embed-context"))
         // error message already printed, eng already feeed
         return 1;
+
+    if (vm.count("ignore-parser-warnings"))
+        eng->setIgnoreParserWarnings(true);
 
     bool hasError = false;
 

--- a/src/lib/writer.cc
+++ b/src/lib/writer.cc
@@ -44,7 +44,7 @@ bool AbstractWriter::handleFile(Parser &parser)
         while (parser.getNext(&def))
             this->handleDef(def);
 
-        return !parser.hasError();
+        return ignoreParserWarnings_ || !parser.hasError();
 }
 
 bool AbstractWriter::handleFile(InStream &input)

--- a/src/lib/writer.hh
+++ b/src/lib/writer.hh
@@ -58,10 +58,15 @@ class AbstractWriter {
 
         virtual void setScanProps(const TScanProps &);
 
+        void setIgnoreParserWarnings(const bool val) {
+            ignoreParserWarnings_ = val;
+        }
+
 
     private:
         EFileFormat                 inputFormat_ = FF_INVALID;
         const TScanProps            emptyProps_{};
+        bool                        ignoreParserWarnings_ = false;
 };
 
 using TWriterPtr = std::unique_ptr<AbstractWriter>;

--- a/tests/csgrep/0002-compiler-warnings-args.txt
+++ b/tests/csgrep/0002-compiler-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet
+--ignore-parser-warnings --quiet

--- a/tests/csgrep/0003-compiler-warnings-args.txt
+++ b/tests/csgrep/0003-compiler-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path '^/builddir/build/BUILD/' --event='warning.*' --remove-duplicates
+--ignore-parser-warnings --quiet --path '^/builddir/build/BUILD/' --event='warning.*' --remove-duplicates

--- a/tests/csgrep/0012-llvm-build-warnings-args.txt
+++ b/tests/csgrep/0012-llvm-build-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path conftest.c --invert-match --remove-duplicates
+--ignore-parser-warnings --quiet --path conftest.c --invert-match --remove-duplicates

--- a/tests/csgrep/0014-llvm-build-warnings-args.txt
+++ b/tests/csgrep/0014-llvm-build-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path conftest.c --invert-match --remove-duplicates --mode=json
+--ignore-parser-warnings --quiet --path conftest.c --invert-match --remove-duplicates --mode=json

--- a/tests/csgrep/0017-compiler-warnings-args.txt
+++ b/tests/csgrep/0017-compiler-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path '^/builddir/build/BUILD/' --event='warning.*' --remove-duplicates
+--ignore-parser-warnings --quiet --path '^/builddir/build/BUILD/' --event='warning.*' --remove-duplicates

--- a/tests/csgrep/0018-compiler-warnings-args.txt
+++ b/tests/csgrep/0018-compiler-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path '^/builddir/build/BUILD/' --event='warning.*' --remove-duplicates
+--ignore-parser-warnings --quiet --path '^/builddir/build/BUILD/' --event='warning.*' --remove-duplicates

--- a/tests/csgrep/0019-clang-warnings-args.txt
+++ b/tests/csgrep/0019-clang-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --remove-duplicates
+--ignore-parser-warnings --quiet --remove-duplicates

--- a/tests/csgrep/0024-compiler-warnings-args.txt
+++ b/tests/csgrep/0024-compiler-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path ^/builddir/build/BUILD/ --strip-path-prefix /builddir/build/BUILD/
+--ignore-parser-warnings --quiet --path ^/builddir/build/BUILD/ --strip-path-prefix /builddir/build/BUILD/

--- a/tests/csgrep/0025-compiler-warnings-args.txt
+++ b/tests/csgrep/0025-compiler-warnings-args.txt
@@ -1,1 +1,1 @@
---quiet --path ^/builddir/build/BUILD/ --strip-path-prefix /builddir/build/BUILD/
+--ignore-parser-warnings --quiet --path ^/builddir/build/BUILD/ --strip-path-prefix /builddir/build/BUILD/

--- a/tests/csgrep/0057-gcc-parser-gcc-analyzer-curl-args.txt
+++ b/tests/csgrep/0057-gcc-parser-gcc-analyzer-curl-args.txt
@@ -1,0 +1,1 @@
+--ignore-parser-warnings --quiet

--- a/tests/csgrep/0063-gcc-parser-checker-lang-args.txt
+++ b/tests/csgrep/0063-gcc-parser-checker-lang-args.txt
@@ -1,1 +1,1 @@
---mode=json --quiet
+--ignore-parser-warnings --mode=json --quiet

--- a/tests/csgrep/0065-gcc-parser-clang-warn-suff-args.txt
+++ b/tests/csgrep/0065-gcc-parser-clang-warn-suff-args.txt
@@ -1,1 +1,1 @@
---mode=json --checker CLANG --prune=0 --quiet
+--ignore-parser-warnings --mode=json --checker CLANG --prune=0 --quiet

--- a/tests/csgrep/0102-xml-parser-empty-args.txt
+++ b/tests/csgrep/0102-xml-parser-empty-args.txt
@@ -1,1 +1,1 @@
---mode=json
+--ignore-parser-warnings --mode=json

--- a/tests/csgrep/0107-gcc-prepend-path-args.txt
+++ b/tests/csgrep/0107-gcc-prepend-path-args.txt
@@ -1,1 +1,1 @@
---mode=json --prepend-path-prefix=/builddir/build/BUILD/ --quiet
+--ignore-parser-warnings --mode=json --prepend-path-prefix=/builddir/build/BUILD/ --quiet


### PR DESCRIPTION
The `--quiet` option controls printing of error/warning messages whereas `--ignore-parser-warnings` controls whether the exit code is affected by the parsers or not.