### PR TITLE
writer-json-sarif: unconditionally set the `region` property

### DIFF
--- a/src/lib/writer-json-sarif.cc
+++ b/src/lib/writer-json-sarif.cc
@@ -212,16 +212,14 @@ static void sarifEncodeLoc(object *pLoc, const Defect &def, unsigned idx)
     };
 
     // line/col
-    if (evt.line) {
-        object reg = {
-            { "startLine", evt.line }
-        };
+    object reg = {
+        { "startLine", evt.line }
+    };
 
-        if (evt.column)
-            reg["startColumn"] = evt.column;
+    if (evt.column)
+        reg["startColumn"] = evt.column;
 
-        locPhy["region"] = std::move(reg);
-    }
+    locPhy["region"] = std::move(reg);
 
     // location
     pLoc->emplace("physicalLocation", std::move(locPhy));

--- a/tests/csgrep/0085-sarif-writer-stdout.txt
+++ b/tests/csgrep/0085-sarif-writer-stdout.txt
@@ -136,6 +136,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -147,6 +150,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -158,6 +164,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -169,6 +178,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -180,6 +192,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -262,6 +277,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -273,6 +291,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -284,6 +305,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -295,6 +319,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -306,6 +333,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -388,6 +418,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -399,6 +432,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -410,6 +446,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -421,6 +460,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -432,6 +474,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -514,6 +559,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -525,6 +573,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -536,6 +587,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -547,6 +601,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -558,6 +615,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -640,6 +700,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -651,6 +714,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -662,6 +728,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -673,6 +742,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -684,6 +756,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -766,6 +841,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -777,6 +855,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -788,6 +869,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -799,6 +883,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -810,6 +897,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -892,6 +982,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -903,6 +996,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -914,6 +1010,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -925,6 +1024,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -936,6 +1038,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1018,6 +1123,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1029,6 +1137,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1040,6 +1151,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1051,6 +1165,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1062,6 +1179,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1144,6 +1264,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1155,6 +1278,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1166,6 +1292,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1177,6 +1306,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1188,6 +1320,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1270,6 +1405,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1281,6 +1419,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1292,6 +1433,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1303,6 +1447,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1314,6 +1461,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1396,6 +1546,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1407,6 +1560,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1418,6 +1574,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1429,6 +1588,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1440,6 +1602,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1522,6 +1687,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1533,6 +1701,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1544,6 +1715,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1555,6 +1729,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1566,6 +1743,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1648,6 +1828,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1659,6 +1842,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1670,6 +1856,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1681,6 +1870,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1692,6 +1884,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1774,6 +1969,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1785,6 +1983,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1796,6 +1997,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1807,6 +2011,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1818,6 +2025,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1900,6 +2110,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1911,6 +2124,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1922,6 +2138,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1933,6 +2152,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1944,6 +2166,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2026,6 +2251,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2037,6 +2265,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2048,6 +2279,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2059,6 +2293,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2070,6 +2307,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2152,6 +2392,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2163,6 +2406,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2174,6 +2420,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2185,6 +2434,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2196,6 +2448,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2278,6 +2533,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2289,6 +2547,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2300,6 +2561,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2311,6 +2575,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2322,6 +2589,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2404,6 +2674,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2415,6 +2688,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2426,6 +2702,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2437,6 +2716,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2448,6 +2730,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2530,6 +2815,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2541,6 +2829,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2552,6 +2843,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2563,6 +2857,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2574,6 +2871,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2656,6 +2956,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2667,6 +2970,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2678,6 +2984,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2689,6 +2998,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2700,6 +3012,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2782,6 +3097,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2793,6 +3111,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2804,6 +3125,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2815,6 +3139,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2826,6 +3153,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             },
                             "message": {

--- a/tests/csgrep/0090-sarif-writer-illegal-utf8-sequence-stdout.txt
+++ b/tests/csgrep/0090-sarif-writer-illegal-utf8-sequence-stdout.txt
@@ -20,6 +20,9 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": "test.c"
+                                },
+                                "region": {
+                                    "startLine": 0
                                 }
                             }
                         }
@@ -38,6 +41,9 @@
                                                 "physicalLocation": {
                                                     "artifactLocation": {
                                                         "uri": "test.c"
+                                                    },
+                                                    "region": {
+                                                        "startLine": 0
                                                     }
                                                 },
                                                 "message": {


### PR DESCRIPTION
... for each `physicalLocation` object.  Although the property is optional according to the specification of SARIF Version 2.1.0, DefectDojo fails to import the data if the property is missing.

Reported-by: Mert Bugra Bicak
Closes: https://github.com/csutils/csdiff/pull/123