### PR TITLE
cslinker: do not abort on empty property in scan.ini

### DIFF
--- a/src/lib/writer-json-common.cc
+++ b/src/lib/writer-json-common.cc
@@ -38,6 +38,10 @@ bool isNumber(const std::string &str)
 {
     static auto isDigit = [](unsigned char c){ return std::isdigit(c); };
 
+    if (str.empty())
+        // an empty string cannot be parsed as a number
+        return false;
+
     return std::all_of(str.begin(), str.end(), isDigit);
 }
 

--- a/src/lib/writer-json-common.cc
+++ b/src/lib/writer-json-common.cc
@@ -33,16 +33,22 @@ std::string sanitizeUTF8(const std::string &str)
     return convert_string<char>(str.data(), str.data() + str.size());
 }
 
+/// return true if the given string represents a number
+bool isNumber(const std::string &str)
+{
+    static auto isDigit = [](unsigned char c){ return std::isdigit(c); };
+
+    return std::all_of(str.begin(), str.end(), isDigit);
+}
+
 // TODO: This should not necessary!  TScanProps should be able to contain
 // any type so that no conversions here are needed.
 object jsonSerializeScanProps(const TScanProps &scanProps)
 {
-    static auto isDigit = [](unsigned char c){ return std::isdigit(c); };
-
     object scan;
     for (const auto &prop : scanProps) {
         const auto &val = prop.second;
-        if (std::all_of(val.begin(), val.end(), isDigit))
+        if (isNumber(val))
             scan[prop.first] = boost::lexical_cast<int>(val);
         else
             scan[prop.first] = val;

--- a/tests/cslinker/0003-ini-parser/runtest.sh
+++ b/tests/cslinker/0003-ini-parser/runtest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+set -x
+
+# run cslinker
+"${CSLINKER_BIN}" --inifile "${TEST_SRC_DIR}/scan.ini" <() > scan-results.json
+
+# compare the results with the expected results
+diff -up "${TEST_SRC_DIR}/scan-results.json" "${PWD}/scan-results.json"

--- a/tests/cslinker/0003-ini-parser/scan-results.json
+++ b/tests/cslinker/0003-ini-parser/scan-results.json
@@ -1,0 +1,17 @@
+{
+    "scan": {
+        "enabled-plugins": "",
+        "exit-code": 0,
+        "host": "f37",
+        "known-false-positives": "/usr/share/csmock/known-false-positives.js",
+        "mock-config": "rhel-8-rhaos-x86_64",
+        "project-name": "openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8",
+        "store-results-to": "/tmp/openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8.tar.xz",
+        "time-created": "2023-06-19 10:27:13",
+        "time-finished": "2023-06-19 10:34:00",
+        "tool": "csmock",
+        "tool-args": "'/usr/bin/csmock' '-r' 'rhel-8-rhaos-x86_64' '-f' 'openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8.src.rpm'",
+        "tool-version": "csmock-3.4.1.20230406.104621.gdb10285.internal-1.fc37"
+    },
+    "defects": []
+}

--- a/tests/cslinker/0003-ini-parser/scan.ini
+++ b/tests/cslinker/0003-ini-parser/scan.ini
@@ -1,0 +1,13 @@
+[scan]
+tool = csmock
+tool-version = csmock-3.4.1.20230406.104621.gdb10285.internal-1.fc37
+tool-args = '/usr/bin/csmock' '-r' 'rhel-8-rhaos-x86_64' '-f' 'openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8.src.rpm'
+host = f37
+store-results-to = /tmp/openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8.tar.xz
+time-created = 2023-06-19 10:27:13
+enabled-plugins = 
+mock-config = rhel-8-rhaos-x86_64
+project-name = openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8
+known-false-positives = /usr/share/csmock/known-false-positives.js
+time-finished = 2023-06-19 10:34:00
+exit-code = 0

--- a/tests/cslinker/0003-ini-parser/sync-expected-output.sh
+++ b/tests/cslinker/0003-ini-parser/sync-expected-output.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -x
+
+# check whether we are invoked from the correct directory
+test -d ../../cslinker/0003-ini-parser/
+
+# find cslinker BINARY
+export CSLINKER_BIN=../../../csdiff_build/src/cslinker
+test -x $CSLINKER_BIN
+CSLINKER_BIN=$(realpath $CSLINKER_BIN)
+
+# run the test in the _source_ directory to overwrite the expected output
+TEST_SRC_DIR="$PWD" ./runtest.sh


### PR DESCRIPTION
```
[...]
>>> 2023-06-19 10:34:00 "cslinker --quiet --cwelist '/usr/share/csmock/cwe-map.csv' --inifile '/tmp/csmocklj8jvfjs/openshift-clients-4.7.0-202103251046.p0.git.3957.c4da68b.el8/scan.ini' '/t
terminate called after throwing an instance of 'boost::wrapexcept<boost::bad_lexical_cast>'
  what():  bad lexical cast: source type value could not be interpreted as target

!!! 2023-06-19 10:34:00 fatal error: caught signal 6
```