### PR TITLE
lint: use std::move() where appropriate

### DIFF
--- a/src/cshtml.cc
+++ b/src/cshtml.cc
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
         // initialize CWE names lookup
         CweNameLookup cweNames;
         if (!fnCweNames.empty()) {
-            InStream strCweNames(fnCweNames);
+            InStream strCweNames(std::move(fnCweNames));
             cweNames.parse(strCweNames);
             writer.setCweNameLookup(&cweNames);
         }

--- a/src/lib/parser-common.cc
+++ b/src/lib/parser-common.cc
@@ -97,7 +97,7 @@ void ImpliedAttrDigger::inferToolFromChecker(
             // we use COMPILER_WARNING for "gcc" due to historical reasons
             tool = "gcc";
 
-        pDef->tool = tool;
+        pDef->tool = std::move(tool);
     }
     else
         // no tool matched --> assume coverity

--- a/src/lib/parser-cov.cc
+++ b/src/lib/parser-cov.cc
@@ -180,7 +180,7 @@ EToken ErrFileLexer::readNext()
     }
 
     if (!boost::regex_match(line, sm, reEvent_)) {
-        evt_.msg = line;
+        evt_.msg = std::move(line);
         return T_UNKNOWN;
     }
 

--- a/src/lib/parser-json-sarif.cc
+++ b/src/lib/parser-json-sarif.cc
@@ -121,14 +121,14 @@ void SarifTreeDecoder::readScanProps(
 
         if (!version.empty())
             // record tool version of Snyk Code
-            (*pDst)["analyzer-version-snyk-code"] = version;
+            (*pDst)["analyzer-version-snyk-code"] = std::move(version);
     }
     else if (name == "gitleaks") {
         // gitleaks
         d->singleChecker = "GITLEAKS_WARNING";
 
         if (!version.empty())
-            (*pDst)["analyzer-version-gitleaks"] = version;
+            (*pDst)["analyzer-version-gitleaks"] = std::move(version);
     }
     else if (boost::starts_with(name, "GNU C")) {
         // GCC

--- a/src/lib/parser-xml-valgrind.cc
+++ b/src/lib/parser-xml-valgrind.cc
@@ -123,7 +123,7 @@ void ValgrindTreeDecoder::readRoot(const pt::ptree *root)
     // create a note event in the defect prototype
     d->defPrototype.events.push_back(DefEvent("note"));
     DefEvent &noteEvt = d->defPrototype.events.back();
-    noteEvt.fileName = exe;
+    noteEvt.fileName = std::move(exe);
 
     // record PID and command-line args
     std::ostringstream str;

--- a/src/lib/writer-html.cc
+++ b/src/lib/writer-html.cc
@@ -271,7 +271,7 @@ void HtmlWriterCore::writeHeaderOnce(
         title = titleFallback_;
 
     // initialize a HTML document
-    HtmlLib::initHtml(str_, title);
+    HtmlLib::initHtml(str_, std::move(title));
     if (!plainTextUrl.empty())
         HtmlLib::writeLink(str_, plainTextUrl, "[Show plain-text results]");
 

--- a/src/lib/writer-json-sarif.cc
+++ b/src/lib/writer-json-sarif.cc
@@ -412,5 +412,5 @@ void SarifTreeEncoder::writeTo(std::ostream &str)
     root["runs"] = array{std::move(run0)};
 
     // encode as JSON
-    jsonPrettyPrint(str, root);
+    jsonPrettyPrint(str, std::move(root));
 }


### PR DESCRIPTION
Suggested by Coverity.