### PR TITLE
writer-json-sarif: fix miscompilation with recent Apple Clang

### DIFF
--- a/src/lib/writer-json-sarif.cc
+++ b/src/lib/writer-json-sarif.cc
@@ -362,9 +362,9 @@ void SarifTreeEncoder::appendDef(const Defect &def)
     }
 
     // codeFlows
-    result["codeFlows"] = {
+    result["codeFlows"] = array{
         // threadFlows
-        {{ "threadFlows", {
+        {{ "threadFlows", array{
             // locations
             {{ "locations", std::move(flowLocs) }}
         }}}
@@ -388,7 +388,7 @@ void SarifTreeEncoder::writeTo(std::ostream &str)
 
     if (!d->scanProps.empty()) {
         // scan props
-        root["inlineExternalProperties"] = {
+        root["inlineExternalProperties"] = array{
             {{ "externalizedProperties", jsonSerializeScanProps(d->scanProps) }}
         };
     }


### PR DESCRIPTION
For a reason I'm too lazy to diagnose, latest releases of Apple Clang now ignore the outermost initializer lists with object initializers which GCC still translates to an array.  Construct the arrays explicitly to avoid this ambiguity.

Resolves: https://github.com/csutils/csdiff/issues/160