### PR TITLE
coding style: rename `parse_int()` -> `parseInt()`

### DIFF
--- a/src/lib/cwe-name-lookup.cc
+++ b/src/lib/cwe-name-lookup.cc
@@ -53,7 +53,7 @@ bool CweNameLookup::handleLine(const TStringList &fields)
 
     // parse CWE number
     const std::string &cweId = fields[/* CWE */ 0];
-    const int cwe = parse_int(cweId, -1);
+    const int cwe = parseInt(cweId, -1);
     if (cwe < 0) {
         // we use "unmapped" for findings without any CWE assigned
         // as discussed in https://github.com/csutils/csdiff/pull/61

--- a/src/lib/parser-common.cc
+++ b/src/lib/parser-common.cc
@@ -25,7 +25,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/lexical_cast.hpp>
 
-int parse_int(const std::string &str, const int fallback)
+int parseInt(const std::string &str, const int fallback)
 {
     try {
         return boost::lexical_cast<int>(str);

--- a/src/lib/parser-common.hh
+++ b/src/lib/parser-common.hh
@@ -38,7 +38,7 @@
 #define RE_EVENT_SIGMA "(?:Sigma (?:main )?event)"
 #define RE_EVENT RE_EVENT_GCC "|" RE_EVENT_PROSPECTOR "|" RE_EVENT_SIGMA
 
-int parse_int(const std::string &, int fallback = 0);
+int parseInt(const std::string &, int fallback = 0);
 
 class ImpliedAttrDigger {
     public:

--- a/src/lib/parser-cov.cc
+++ b/src/lib/parser-cov.cc
@@ -190,10 +190,10 @@ EToken ErrFileLexer::readNext()
     evt_.msg        = sm[/* msg   */ 5];
 
     // parse line number
-    evt_.line = parse_int(sm[/* line */ 2]);
+    evt_.line = parseInt(sm[/* line */ 2]);
 
     // parse column number
-    evt_.column = parse_int(sm[/* col */ 3]);
+    evt_.column = parseInt(sm[/* col */ 3]);
 
     return T_EVENT;
 }
@@ -479,7 +479,7 @@ void AnnotHandler::handleDef(Defect *pDef)
 {
     boost::smatch sm;
     if (boost::regex_match(pDef->annotation, sm, reCweAnnot_)) {
-        pDef->cwe = parse_int(sm[/* cwe */ 1]);
+        pDef->cwe = parseInt(sm[/* cwe */ 1]);
         pDef->annotation.clear();
     }
 }

--- a/src/lib/parser-gcc.cc
+++ b/src/lib/parser-gcc.cc
@@ -178,10 +178,10 @@ EToken Tokenizer::readNext(DefEvent *pEvt)
     pEvt->fileName    = sm["file"];
 
     // parse line number
-    pEvt->line = parse_int(sm["line"]);
+    pEvt->line = parseInt(sm["line"]);
 
     // parse column number
-    pEvt->column = parse_int(sm["col"]);
+    pEvt->column = parseInt(sm["col"]);
 
     return tok;
 }
@@ -467,7 +467,7 @@ bool BasicGccParser::digCppcheckEvt(Defect *pDef)
     keyEvt.event += "]";
 
     // store CWE if available
-    pDef->cwe = parse_int(sm[/* cwe */ 2]);
+    pDef->cwe = parseInt(sm[/* cwe */ 2]);
 
     // this assignment invalidates sm!
     keyEvt.msg = sm[/* msg */ 3];
@@ -628,7 +628,7 @@ void GccPostProcessor::Private::transGccAnal(Defect *pDef) const
     if (!boost::regex_match(keyEvt.msg, sm, this->reGccAnalCwe))
         return;
 
-    pDef->cwe = parse_int(sm[/* cwe */ 2]);
+    pDef->cwe = parseInt(sm[/* cwe */ 2]);
     // this invalidates sm
     keyEvt.msg = sm[/* msg */ 1];
 }


### PR DESCRIPTION
... for consistency.  We use camel-case to name our own functions.