### PR TITLE
propagate endLine/endColumn

### DIFF
--- a/src/lib/defect.hh
+++ b/src/lib/defect.hh
@@ -20,6 +20,7 @@
 #ifndef H_GUARD_DEFECT_H
 #define H_GUARD_DEFECT_H
 
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -54,6 +55,10 @@ struct DefEvent {
     /// 0 = key event,  1 = info event,  2 = trace event
     int                 verbosityLevel  = 0;
 
+    using TNumDiff = unsigned short;
+    TNumDiff            hSize           = 0; //< endColumn - startColumn
+    TNumDiff            vSize           = 0; //< endLine - startLine
+
     DefEvent() { }
 
     explicit DefEvent(const std::string &event):
@@ -61,6 +66,15 @@ struct DefEvent {
     {
     }
 };
+
+///< return (end - beg) if it is positive and fits into target type, 0 otherwise
+inline DefEvent::TNumDiff diffNums(const int beg, const int end)
+{
+    const int diff = end - beg;
+    return (0 < diff && diff < std::numeric_limits<DefEvent::TNumDiff>::max())
+        ? diff
+        : 0;
+}
 
 inline bool cmpEvents(bool *pResult, const DefEvent &a, const DefEvent &b)
 {
@@ -70,6 +84,8 @@ inline bool cmpEvents(bool *pResult, const DefEvent &a, const DefEvent &b)
     RETURN_BY_REF_IF_COMPARED(a, b, event);
     RETURN_BY_REF_IF_COMPARED(a, b, msg);
     RETURN_BY_REF_IF_COMPARED(a, b, verbosityLevel);
+    RETURN_BY_REF_IF_COMPARED(a, b, hSize);
+    RETURN_BY_REF_IF_COMPARED(a, b, vSize);
 
     // incomparable events
     return false;

--- a/src/lib/parser-json-gcc.cc
+++ b/src/lib/parser-json-gcc.cc
@@ -21,6 +21,8 @@
 
 #include "parser-gcc.hh"            // for GccPostProcessor
 
+using std::string;
+
 struct GccTreeDecoder::Private {
     GccPostProcessor            postProc;
 };
@@ -32,10 +34,56 @@ GccTreeDecoder::GccTreeDecoder():
 
 GccTreeDecoder::~GccTreeDecoder() = default;
 
+static bool gccReadLocRegion(
+        DefEvent           *pEvt,
+        const pt::ptree    &start,
+        const pt::ptree    &finish)
+{
+    // read file name
+    pEvt->fileName = valueOf<string>(start, "file", "<unknown>");
+    if (pEvt->fileName != valueOf<string>(finish, "file", "<unknown>"))
+        return false;
+
+    // read line
+    if ((pEvt->line = valueOf<int>(start, "line"))) {
+        const int endLine = valueOf<int>(finish, "line");
+        pEvt->vSize = diffNums(pEvt->line, endLine);
+    }
+
+    // read column
+    if ((pEvt->column = valueOf<int>(start, "byte-column"))) {
+        const int endColumn = valueOf<int>(finish, "byte-column");
+        pEvt->hSize = diffNums(pEvt->column, endColumn);
+    }
+
+    return true;
+}
+
+static void gccReadLocation(DefEvent *pEvt, const pt::ptree *locs)
+{
+    if (locs->empty())
+        return;
+
+    const pt::ptree &firstLoc = locs->begin()->second;
+
+    // try to read a region between start..finish
+    const pt::ptree *start, *finish;
+    if (findChildOf(&start, firstLoc, "start")
+            && findChildOf(&finish, firstLoc, "finish")
+            && gccReadLocRegion(pEvt, *start, *finish))
+        return;
+
+    // fallback to caret
+    const pt::ptree *caret;
+    if (findChildOf(&caret, firstLoc, "caret")) {
+        pEvt->fileName  = valueOf<string>(*caret, "file", "<unknown>");
+        pEvt->line      = valueOf<int>   (*caret, "line");
+        pEvt->column    = valueOf<int>   (*caret, "byte-column");
+    }
+}
+
 static bool gccReadEvent(DefEvent *pEvt, const pt::ptree &evtNode)
 {
-    using std::string;
-
     // read kind (error, warning, note)
     string &evtName = pEvt->event;
     evtName = valueOf<string>(evtNode, "kind");
@@ -45,14 +93,8 @@ static bool gccReadEvent(DefEvent *pEvt, const pt::ptree &evtNode)
     // read location
     pEvt->fileName = "<unknown>";
     const pt::ptree *locs;
-    if (findChildOf(&locs, evtNode, "locations") && !locs->empty()) {
-        const pt::ptree *caret;
-        if (findChildOf(&caret, locs->begin()->second, "caret")) {
-            pEvt->fileName  = valueOf<string>(*caret, "file", "<unknown>");
-            pEvt->line      = valueOf<int>   (*caret, "line");
-            pEvt->column    = valueOf<int>   (*caret, "byte-column");
-        }
-    }
+    if (findChildOf(&locs, evtNode, "locations"))
+        gccReadLocation(pEvt, locs);
 
     // read message
     pEvt->msg = valueOf<string>(evtNode, "message", "<unknown>");

--- a/src/lib/parser-json-sarif.cc
+++ b/src/lib/parser-json-sarif.cc
@@ -178,9 +178,17 @@ static void sarifReadLocation(DefEvent *pEvt, const pt::ptree &loc)
 
     const pt::ptree *reg;
     if (findChildOf(&reg, *pl, "region")) {
-        // read line/col if available
-        pEvt->line = valueOf<int>(*reg, "startLine");
-        pEvt->column = valueOf<int>(*reg, "startColumn");
+        // read line
+        if ((pEvt->line = valueOf<int>(*reg, "startLine"))) {
+            const int endLine = valueOf<int>(*reg, "endLine");
+            pEvt->vSize = diffNums(pEvt->line, endLine);
+        }
+
+        // read column
+        if ((pEvt->column = valueOf<int>(*reg, "startColumn"))) {
+            const int endColumn = valueOf<int>(*reg, "endColumn");
+            pEvt->hSize = diffNums(pEvt->column, endColumn);
+        }
     }
 }
 

--- a/src/lib/parser-json-shchk.cc
+++ b/src/lib/parser-json-shchk.cc
@@ -42,10 +42,20 @@ static bool scReadEvent(DefEvent *pEvt, const pt::ptree &evtNode)
     if (evtName.empty())
         return false;
 
-    // read location
+    // read path
     pEvt->fileName = valueOf<string>(evtNode, "file", "<unknown>");
-    pEvt->line     = valueOf<int>   (evtNode, "line");
-    pEvt->column   = valueOf<int>   (evtNode, "column");
+
+    // read line
+    if ((pEvt->line = valueOf<int>(evtNode, "line"))) {
+        const int endLine = valueOf<int>(evtNode, "endLine");
+        pEvt->vSize = diffNums(pEvt->line, endLine);
+    }
+
+    // read column
+    if ((pEvt->column = valueOf<int>(evtNode, "column"))) {
+        const int endColumn = valueOf<int>(evtNode, "endColumn");
+        pEvt->hSize = diffNums(pEvt->column, endColumn);
+    }
 
     // read message
     pEvt->msg = valueOf<string>(evtNode, "message", "<unknown>");

--- a/src/lib/parser-json-simple.cc
+++ b/src/lib/parser-json-simple.cc
@@ -71,8 +71,10 @@ SimpleTreeDecoder::Private::Private(InStream &input):
         "column",
         "event",
         "file_name",
+        "h_size",
         "line",
         "message",
+        "v_size",
         "verbosity_level",
     };
 }
@@ -134,6 +136,8 @@ bool SimpleTreeDecoder::readNode(Defect *def)
     TEvtList &evtListDst = def->events;
     const pt::ptree &evtListSrc = defNode.get_child("events");
     for (const pt::ptree::value_type &evtItem : evtListSrc) {
+        using TNumDiff = DefEvent::TNumDiff;
+
         const pt::ptree &evtNode = evtItem.second;
         d->reportUnknownNodes(Private::NK_EVENT, evtNode);
 
@@ -141,6 +145,8 @@ bool SimpleTreeDecoder::readNode(Defect *def)
         evt.fileName    = valueOf<std::string   >(evtNode, "file_name");
         evt.line        = valueOf<int           >(evtNode, "line");
         evt.column      = valueOf<int           >(evtNode, "column");
+        evt.hSize       = valueOf<TNumDiff      >(evtNode, "h_size");
+        evt.vSize       = valueOf<TNumDiff      >(evtNode, "v_size");
         evt.event       = valueOf<std::string   >(evtNode, "event");
         evt.msg         = valueOf<std::string   >(evtNode, "message");
         evt.verbosityLevel = valueOf<int>(evtNode, "verbosity_level", -1);

--- a/src/lib/writer-json-sarif.cc
+++ b/src/lib/writer-json-sarif.cc
@@ -231,16 +231,14 @@ static void sarifEncodeLoc(object *pLoc, const Defect &def, unsigned idx)
     if (evt.line) {
         // line start/end
         object reg = {
-            { "startLine", evt.line }
+            { "startLine", evt.line },
+            { "endLine", evt.line + evt.vSize }
         };
-        if (0 < evt.vSize)
-            reg["endLine"] = evt.line + evt.vSize;
 
         // column start/end
         if (evt.column) {
             reg["startColumn"] = evt.column;
-            if (0 < evt.hSize)
-                reg["endColumn"] = evt.column + evt.hSize;
+            reg["endColumn"] = evt.column + evt.hSize;
         }
 
         locPhy["region"] = std::move(reg);

--- a/src/lib/writer-json-sarif.cc
+++ b/src/lib/writer-json-sarif.cc
@@ -229,13 +229,19 @@ static void sarifEncodeLoc(object *pLoc, const Defect &def, unsigned idx)
     };
 
     if (evt.line) {
-        // line/col
+        // line start/end
         object reg = {
             { "startLine", evt.line }
         };
+        if (0 < evt.vSize)
+            reg["endLine"] = evt.line + evt.vSize;
 
-        if (evt.column)
+        // column start/end
+        if (evt.column) {
             reg["startColumn"] = evt.column;
+            if (0 < evt.hSize)
+                reg["endColumn"] = evt.column + evt.hSize;
+        }
 
         locPhy["region"] = std::move(reg);
     }

--- a/src/lib/writer-json-simple.cc
+++ b/src/lib/writer-json-simple.cc
@@ -43,6 +43,10 @@ void SimpleTreeEncoder::appendDef(const Defect &def)
         evtNode["line"] = evt.line;
         if (0 < evt.column)
             evtNode["column"] = evt.column;
+        if (0 < evt.hSize)
+            evtNode["h_size"] = evt.hSize;
+        if (0 < evt.vSize)
+            evtNode["v_size"] = evt.vSize;
 
         // describe the event
         evtNode["event"] = evt.event;

--- a/tests/csgrep/0078-json-parser-snyk-code-stdout.txt
+++ b/tests/csgrep/0078-json-parser-snyk-code-stdout.txt
@@ -12,6 +12,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 1806,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -27,6 +28,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 1866,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -42,6 +44,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2102,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -57,6 +60,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2109,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -72,6 +76,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2122,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -87,6 +92,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 554,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -102,6 +108,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1160,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -117,6 +124,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1167,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -132,6 +140,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1669,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -147,6 +156,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1988,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -162,6 +172,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1998,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -177,6 +188,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2911,
                     "column": 13,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -192,6 +204,7 @@
                     "file_name": "Src/string.c",
                     "line": 40,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -207,6 +220,7 @@
                     "file_name": "Src/string.c",
                     "line": 71,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -222,6 +236,7 @@
                     "file_name": "Src/string.c",
                     "line": 84,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -237,6 +252,7 @@
                     "file_name": "Src/string.c",
                     "line": 121,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -252,6 +268,7 @@
                     "file_name": "Src/string.c",
                     "line": 122,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -267,6 +284,7 @@
                     "file_name": "Src/string.c",
                     "line": 123,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -282,6 +300,7 @@
                     "file_name": "Src/string.c",
                     "line": 136,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -297,6 +316,7 @@
                     "file_name": "Src/string.c",
                     "line": 137,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -312,6 +332,7 @@
                     "file_name": "Src/string.c",
                     "line": 138,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -327,6 +348,7 @@
                     "file_name": "Src/string.c",
                     "line": 153,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -342,6 +364,7 @@
                     "file_name": "Src/string.c",
                     "line": 154,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -357,6 +380,7 @@
                     "file_name": "Src/string.c",
                     "line": 167,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -372,6 +396,7 @@
                     "file_name": "Src/string.c",
                     "line": 168,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -387,6 +412,7 @@
                     "file_name": "Src/parse.c",
                     "line": 3332,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -402,6 +428,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1412,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -417,6 +444,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1565,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -432,6 +460,7 @@
                     "file_name": "Src/Zle/zle_hist.c",
                     "line": 1640,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -447,6 +476,7 @@
                     "file_name": "Src/Zle/zle_hist.c",
                     "line": 1903,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -462,6 +492,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 231,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -477,6 +508,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 270,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -492,6 +524,7 @@
                     "file_name": "Src/hashtable.c",
                     "line": 666,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -507,6 +540,7 @@
                     "file_name": "Src/hist.c",
                     "line": 2380,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -522,6 +556,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 682,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -537,6 +572,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 943,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -552,6 +588,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 959,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -567,6 +604,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 2848,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -582,6 +620,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 841,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -597,6 +636,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1242,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -612,6 +652,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1339,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -627,6 +668,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1404,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -642,6 +684,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1410,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -657,6 +700,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 1461,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -672,6 +716,7 @@
                     "file_name": "Src/subst.c",
                     "line": 417,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -687,6 +732,7 @@
                     "file_name": "Src/subst.c",
                     "line": 418,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -702,6 +748,7 @@
                     "file_name": "Src/subst.c",
                     "line": 427,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -717,6 +764,7 @@
                     "file_name": "Src/subst.c",
                     "line": 428,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -732,6 +780,7 @@
                     "file_name": "Src/subst.c",
                     "line": 429,
                     "column": 12,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -747,6 +796,7 @@
                     "file_name": "Src/subst.c",
                     "line": 828,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -762,6 +812,7 @@
                     "file_name": "Src/subst.c",
                     "line": 833,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -777,6 +828,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3790,
                     "column": 4,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -792,6 +844,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3833,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -807,6 +860,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3995,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -822,6 +876,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3999,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -837,6 +892,7 @@
                     "file_name": "Src/subst.c",
                     "line": 4002,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -852,6 +908,7 @@
                     "file_name": "Src/input.c",
                     "line": 464,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -867,6 +924,7 @@
                     "file_name": "Src/glob.c",
                     "line": 290,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -882,6 +940,7 @@
                     "file_name": "Src/glob.c",
                     "line": 291,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -897,6 +956,7 @@
                     "file_name": "Src/glob.c",
                     "line": 660,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -912,6 +972,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2448,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -927,6 +988,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2452,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -942,6 +1004,7 @@
                     "file_name": "Src/Modules/tcp.c",
                     "line": 82,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -957,6 +1020,7 @@
                     "file_name": "Src/compat.c",
                     "line": 73,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -972,6 +1036,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 2242,
                     "column": 4,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -987,6 +1052,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 2828,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1002,6 +1068,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 2832,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1017,6 +1084,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3262,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1032,6 +1100,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3266,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1047,6 +1116,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3268,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1062,6 +1132,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3323,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1077,6 +1148,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3383,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1092,6 +1164,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3387,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1107,6 +1180,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3430,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1122,6 +1196,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3467,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1137,6 +1212,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3483,
                     "column": 4,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1152,6 +1228,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3541,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1167,6 +1244,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3584,
                     "column": 9,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1182,6 +1260,7 @@
                     "file_name": "Src/Zle/zle_vi.c",
                     "line": 110,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1197,6 +1276,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 557,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1212,6 +1292,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 3026,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1227,6 +1308,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2240,
                     "column": 13,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1242,6 +1324,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2242,
                     "column": 13,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1257,6 +1340,7 @@
                     "file_name": "Src/string.c",
                     "line": 203,
                     "column": 12,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1272,6 +1356,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 512,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1287,6 +1372,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1413,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1302,6 +1388,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1414,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1317,6 +1404,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 233,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1332,6 +1420,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 272,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1347,6 +1436,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 418,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1362,6 +1452,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 420,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1377,6 +1468,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 496,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1392,6 +1484,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 498,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1407,6 +1500,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1260,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1422,6 +1516,7 @@
                     "file_name": "Src/Zle/zleparameter.c",
                     "line": 48,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1437,6 +1532,7 @@
                     "file_name": "Src/Zle/zleparameter.c",
                     "line": 50,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1452,6 +1548,7 @@
                     "file_name": "Src/Zle/zle_refresh.c",
                     "line": 446,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1467,6 +1564,7 @@
                     "file_name": "Src/subst.c",
                     "line": 4223,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1482,6 +1580,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2322,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1497,6 +1596,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2401,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1512,6 +1612,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2484,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1527,6 +1628,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3433,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1542,6 +1644,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 724,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1557,6 +1660,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 733,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1572,6 +1676,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 846,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1587,6 +1692,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 858,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1602,6 +1708,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 1787,
                     "column": 18,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1617,6 +1724,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2113,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1632,6 +1740,7 @@
                     "file_name": "Src/module.c",
                     "line": 3463,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1647,6 +1756,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 1025,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1662,6 +1772,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1198,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1677,6 +1788,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1205,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1692,6 +1804,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1207,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1707,6 +1820,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1213,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1722,6 +1836,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1219,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1737,6 +1852,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1220,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1752,6 +1868,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1229,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1767,6 +1884,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1241,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1782,6 +1900,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2561,
                     "column": 21,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1797,6 +1916,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 505,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1812,6 +1932,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 1069,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1827,6 +1948,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 1102,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1842,6 +1964,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 664,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1857,6 +1980,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 696,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1872,6 +1996,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 735,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1887,6 +2012,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 759,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1902,6 +2028,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1357,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1917,6 +2044,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1363,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1932,6 +2060,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1368,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1947,6 +2076,7 @@
                     "file_name": "Src/hashtable.c",
                     "line": 652,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1962,6 +2092,7 @@
                     "file_name": "Src/text.c",
                     "line": 104,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1977,6 +2108,7 @@
                     "file_name": "Src/text.c",
                     "line": 107,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1992,6 +2124,7 @@
                     "file_name": "Src/pattern.c",
                     "line": 2586,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2007,6 +2140,7 @@
                     "file_name": "Src/pattern.c",
                     "line": 2591,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2022,6 +2156,7 @@
                     "file_name": "Src/hist.c",
                     "line": 3301,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2037,6 +2172,7 @@
                     "file_name": "Src/cond.c",
                     "line": 116,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2052,6 +2188,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 844,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2067,6 +2204,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 848,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2082,6 +2220,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 50,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2097,6 +2236,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 135,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2112,6 +2252,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 151,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2127,6 +2268,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 164,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2142,6 +2284,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 180,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2157,6 +2300,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 194,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2172,6 +2316,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 213,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2187,6 +2332,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 239,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2202,6 +2348,7 @@
                     "file_name": "Src/Zle/zle_refresh.c",
                     "line": 438,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2217,6 +2364,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2550,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2232,6 +2380,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2554,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2247,6 +2396,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2558,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2262,6 +2412,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2562,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2277,6 +2428,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2873,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2292,6 +2444,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2879,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2307,6 +2460,7 @@
                     "file_name": "Src/signals.c",
                     "line": 1361,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2322,6 +2476,7 @@
                     "file_name": "Src/subst.c",
                     "line": 1511,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2337,6 +2492,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3596,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2352,6 +2508,7 @@
                     "file_name": "Src/Modules/datetime.c",
                     "line": 229,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2367,6 +2524,7 @@
                     "file_name": "Src/Modules/datetime.c",
                     "line": 231,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2382,6 +2540,7 @@
                     "file_name": "Src/Builtins/sched.c",
                     "line": 359,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2397,6 +2556,7 @@
                     "file_name": "Src/Builtins/sched.c",
                     "line": 366,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2412,6 +2572,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2321,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2427,6 +2588,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2399,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2442,6 +2604,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2579,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2457,6 +2620,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2584,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2472,6 +2636,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2590,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2487,6 +2652,7 @@
                     "file_name": "Src/Modules/system.c",
                     "line": 521,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2502,6 +2668,7 @@
                     "file_name": "Src/Zle/zle_keymap.c",
                     "line": 1286,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2517,6 +2684,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3767,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2532,6 +2700,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3891,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2547,6 +2716,7 @@
                     "file_name": "Src/Modules/curses.c",
                     "line": 1231,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0

--- a/tests/csgrep/0080-sarif-writer-stdout.txt
+++ b/tests/csgrep/0080-sarif-writer-stdout.txt
@@ -30,7 +30,9 @@
                                 },
                                 "region": {
                                     "startLine": 1806,
-                                    "startColumn": 6
+                                    "endLine": 1806,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -52,7 +54,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1806,
-                                                        "startColumn": 6
+                                                        "endLine": 1806,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -82,7 +86,9 @@
                                 },
                                 "region": {
                                     "startLine": 1866,
-                                    "startColumn": 3
+                                    "endLine": 1866,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -104,7 +110,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1866,
-                                                        "startColumn": 3
+                                                        "endLine": 1866,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -134,7 +142,9 @@
                                 },
                                 "region": {
                                     "startLine": 2102,
-                                    "startColumn": 2
+                                    "endLine": 2102,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -156,7 +166,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2102,
-                                                        "startColumn": 2
+                                                        "endLine": 2102,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -186,7 +198,9 @@
                                 },
                                 "region": {
                                     "startLine": 2109,
-                                    "startColumn": 6
+                                    "endLine": 2109,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -208,7 +222,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2109,
-                                                        "startColumn": 6
+                                                        "endLine": 2109,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -238,7 +254,9 @@
                                 },
                                 "region": {
                                     "startLine": 2122,
-                                    "startColumn": 2
+                                    "endLine": 2122,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -260,7 +278,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2122,
-                                                        "startColumn": 2
+                                                        "endLine": 2122,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -290,7 +310,9 @@
                                 },
                                 "region": {
                                     "startLine": 554,
-                                    "startColumn": 5
+                                    "endLine": 554,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -312,7 +334,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 554,
-                                                        "startColumn": 5
+                                                        "endLine": 554,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -342,7 +366,9 @@
                                 },
                                 "region": {
                                     "startLine": 1160,
-                                    "startColumn": 6
+                                    "endLine": 1160,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -364,7 +390,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1160,
-                                                        "startColumn": 6
+                                                        "endLine": 1160,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -394,7 +422,9 @@
                                 },
                                 "region": {
                                     "startLine": 1167,
-                                    "startColumn": 3
+                                    "endLine": 1167,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -416,7 +446,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1167,
-                                                        "startColumn": 3
+                                                        "endLine": 1167,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -446,7 +478,9 @@
                                 },
                                 "region": {
                                     "startLine": 1669,
-                                    "startColumn": 3
+                                    "endLine": 1669,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -468,7 +502,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1669,
-                                                        "startColumn": 3
+                                                        "endLine": 1669,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -498,7 +534,9 @@
                                 },
                                 "region": {
                                     "startLine": 1988,
-                                    "startColumn": 7
+                                    "endLine": 1988,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -520,7 +558,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1988,
-                                                        "startColumn": 7
+                                                        "endLine": 1988,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -550,7 +590,9 @@
                                 },
                                 "region": {
                                     "startLine": 1998,
-                                    "startColumn": 8
+                                    "endLine": 1998,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -572,7 +614,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1998,
-                                                        "startColumn": 8
+                                                        "endLine": 1998,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -602,7 +646,9 @@
                                 },
                                 "region": {
                                     "startLine": 2911,
-                                    "startColumn": 13
+                                    "endLine": 2911,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -624,7 +670,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2911,
-                                                        "startColumn": 13
+                                                        "endLine": 2911,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -654,7 +702,9 @@
                                 },
                                 "region": {
                                     "startLine": 40,
-                                    "startColumn": 5
+                                    "endLine": 40,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -676,7 +726,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 40,
-                                                        "startColumn": 5
+                                                        "endLine": 40,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -706,7 +758,9 @@
                                 },
                                 "region": {
                                     "startLine": 71,
-                                    "startColumn": 5
+                                    "endLine": 71,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -728,7 +782,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 71,
-                                                        "startColumn": 5
+                                                        "endLine": 71,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -758,7 +814,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 5
+                                    "endLine": 84,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -780,7 +838,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 5
+                                                        "endLine": 84,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -810,7 +870,9 @@
                                 },
                                 "region": {
                                     "startLine": 121,
-                                    "startColumn": 5
+                                    "endLine": 121,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -832,7 +894,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 121,
-                                                        "startColumn": 5
+                                                        "endLine": 121,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -862,7 +926,9 @@
                                 },
                                 "region": {
                                     "startLine": 122,
-                                    "startColumn": 5
+                                    "endLine": 122,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -884,7 +950,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 122,
-                                                        "startColumn": 5
+                                                        "endLine": 122,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -914,7 +982,9 @@
                                 },
                                 "region": {
                                     "startLine": 123,
-                                    "startColumn": 5
+                                    "endLine": 123,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -936,7 +1006,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 123,
-                                                        "startColumn": 5
+                                                        "endLine": 123,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -966,7 +1038,9 @@
                                 },
                                 "region": {
                                     "startLine": 136,
-                                    "startColumn": 5
+                                    "endLine": 136,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -988,7 +1062,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 136,
-                                                        "startColumn": 5
+                                                        "endLine": 136,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1018,7 +1094,9 @@
                                 },
                                 "region": {
                                     "startLine": 137,
-                                    "startColumn": 5
+                                    "endLine": 137,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1040,7 +1118,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 137,
-                                                        "startColumn": 5
+                                                        "endLine": 137,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1070,7 +1150,9 @@
                                 },
                                 "region": {
                                     "startLine": 138,
-                                    "startColumn": 5
+                                    "endLine": 138,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1092,7 +1174,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 138,
-                                                        "startColumn": 5
+                                                        "endLine": 138,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1122,7 +1206,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 5
+                                    "endLine": 153,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1144,7 +1230,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 5
+                                                        "endLine": 153,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1174,7 +1262,9 @@
                                 },
                                 "region": {
                                     "startLine": 154,
-                                    "startColumn": 5
+                                    "endLine": 154,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1196,7 +1286,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 154,
-                                                        "startColumn": 5
+                                                        "endLine": 154,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1226,7 +1318,9 @@
                                 },
                                 "region": {
                                     "startLine": 167,
-                                    "startColumn": 5
+                                    "endLine": 167,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1248,7 +1342,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 167,
-                                                        "startColumn": 5
+                                                        "endLine": 167,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1278,7 +1374,9 @@
                                 },
                                 "region": {
                                     "startLine": 168,
-                                    "startColumn": 5
+                                    "endLine": 168,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1300,7 +1398,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 168,
-                                                        "startColumn": 5
+                                                        "endLine": 168,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1330,7 +1430,9 @@
                                 },
                                 "region": {
                                     "startLine": 3332,
-                                    "startColumn": 2
+                                    "endLine": 3332,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -1352,7 +1454,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3332,
-                                                        "startColumn": 2
+                                                        "endLine": 3332,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -1382,7 +1486,9 @@
                                 },
                                 "region": {
                                     "startLine": 1412,
-                                    "startColumn": 5
+                                    "endLine": 1412,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1404,7 +1510,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1412,
-                                                        "startColumn": 5
+                                                        "endLine": 1412,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1434,7 +1542,9 @@
                                 },
                                 "region": {
                                     "startLine": 1565,
-                                    "startColumn": 5
+                                    "endLine": 1565,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1456,7 +1566,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1565,
-                                                        "startColumn": 5
+                                                        "endLine": 1565,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1486,7 +1598,9 @@
                                 },
                                 "region": {
                                     "startLine": 1640,
-                                    "startColumn": 6
+                                    "endLine": 1640,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1508,7 +1622,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1640,
-                                                        "startColumn": 6
+                                                        "endLine": 1640,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1538,7 +1654,9 @@
                                 },
                                 "region": {
                                     "startLine": 1903,
-                                    "startColumn": 3
+                                    "endLine": 1903,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -1560,7 +1678,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1903,
-                                                        "startColumn": 3
+                                                        "endLine": 1903,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -1590,7 +1710,9 @@
                                 },
                                 "region": {
                                     "startLine": 231,
-                                    "startColumn": 6
+                                    "endLine": 231,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1612,7 +1734,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 231,
-                                                        "startColumn": 6
+                                                        "endLine": 231,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1642,7 +1766,9 @@
                                 },
                                 "region": {
                                     "startLine": 270,
-                                    "startColumn": 7
+                                    "endLine": 270,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -1664,7 +1790,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 270,
-                                                        "startColumn": 7
+                                                        "endLine": 270,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -1694,7 +1822,9 @@
                                 },
                                 "region": {
                                     "startLine": 666,
-                                    "startColumn": 3
+                                    "endLine": 666,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -1716,7 +1846,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 666,
-                                                        "startColumn": 3
+                                                        "endLine": 666,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -1746,7 +1878,9 @@
                                 },
                                 "region": {
                                     "startLine": 2380,
-                                    "startColumn": 6
+                                    "endLine": 2380,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1768,7 +1902,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2380,
-                                                        "startColumn": 6
+                                                        "endLine": 2380,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1798,7 +1934,9 @@
                                 },
                                 "region": {
                                     "startLine": 682,
-                                    "startColumn": 6
+                                    "endLine": 682,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1820,7 +1958,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 682,
-                                                        "startColumn": 6
+                                                        "endLine": 682,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1850,7 +1990,9 @@
                                 },
                                 "region": {
                                     "startLine": 943,
-                                    "startColumn": 2
+                                    "endLine": 943,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -1872,7 +2014,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 943,
-                                                        "startColumn": 2
+                                                        "endLine": 943,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -1902,7 +2046,9 @@
                                 },
                                 "region": {
                                     "startLine": 959,
-                                    "startColumn": 5
+                                    "endLine": 959,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1924,7 +2070,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 959,
-                                                        "startColumn": 5
+                                                        "endLine": 959,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -1954,7 +2102,9 @@
                                 },
                                 "region": {
                                     "startLine": 2848,
-                                    "startColumn": 5
+                                    "endLine": 2848,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -1976,7 +2126,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2848,
-                                                        "startColumn": 5
+                                                        "endLine": 2848,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -2006,7 +2158,9 @@
                                 },
                                 "region": {
                                     "startLine": 841,
-                                    "startColumn": 6
+                                    "endLine": 841,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -2028,7 +2182,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 841,
-                                                        "startColumn": 6
+                                                        "endLine": 841,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -2058,7 +2214,9 @@
                                 },
                                 "region": {
                                     "startLine": 1242,
-                                    "startColumn": 5
+                                    "endLine": 1242,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -2080,7 +2238,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1242,
-                                                        "startColumn": 5
+                                                        "endLine": 1242,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -2110,7 +2270,9 @@
                                 },
                                 "region": {
                                     "startLine": 1339,
-                                    "startColumn": 3
+                                    "endLine": 1339,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -2132,7 +2294,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1339,
-                                                        "startColumn": 3
+                                                        "endLine": 1339,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -2162,7 +2326,9 @@
                                 },
                                 "region": {
                                     "startLine": 1404,
-                                    "startColumn": 7
+                                    "endLine": 1404,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -2184,7 +2350,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1404,
-                                                        "startColumn": 7
+                                                        "endLine": 1404,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -2214,7 +2382,9 @@
                                 },
                                 "region": {
                                     "startLine": 1410,
-                                    "startColumn": 7
+                                    "endLine": 1410,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -2236,7 +2406,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1410,
-                                                        "startColumn": 7
+                                                        "endLine": 1410,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -2266,7 +2438,9 @@
                                 },
                                 "region": {
                                     "startLine": 1461,
-                                    "startColumn": 2
+                                    "endLine": 1461,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -2288,7 +2462,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1461,
-                                                        "startColumn": 2
+                                                        "endLine": 1461,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -2318,7 +2494,9 @@
                                 },
                                 "region": {
                                     "startLine": 417,
-                                    "startColumn": 3
+                                    "endLine": 417,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -2340,7 +2518,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 417,
-                                                        "startColumn": 3
+                                                        "endLine": 417,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -2370,7 +2550,9 @@
                                 },
                                 "region": {
                                     "startLine": 418,
-                                    "startColumn": 3
+                                    "endLine": 418,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -2392,7 +2574,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 418,
-                                                        "startColumn": 3
+                                                        "endLine": 418,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -2422,7 +2606,9 @@
                                 },
                                 "region": {
                                     "startLine": 427,
-                                    "startColumn": 3
+                                    "endLine": 427,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -2444,7 +2630,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 427,
-                                                        "startColumn": 3
+                                                        "endLine": 427,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -2474,7 +2662,9 @@
                                 },
                                 "region": {
                                     "startLine": 428,
-                                    "startColumn": 6
+                                    "endLine": 428,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -2496,7 +2686,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 428,
-                                                        "startColumn": 6
+                                                        "endLine": 428,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -2526,7 +2718,9 @@
                                 },
                                 "region": {
                                     "startLine": 429,
-                                    "startColumn": 12
+                                    "endLine": 429,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -2548,7 +2742,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 429,
-                                                        "startColumn": 12
+                                                        "endLine": 429,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -2578,7 +2774,9 @@
                                 },
                                 "region": {
                                     "startLine": 828,
-                                    "startColumn": 2
+                                    "endLine": 828,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -2600,7 +2798,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 828,
-                                                        "startColumn": 2
+                                                        "endLine": 828,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -2630,7 +2830,9 @@
                                 },
                                 "region": {
                                     "startLine": 833,
-                                    "startColumn": 6
+                                    "endLine": 833,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -2652,7 +2854,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 833,
-                                                        "startColumn": 6
+                                                        "endLine": 833,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -2682,7 +2886,9 @@
                                 },
                                 "region": {
                                     "startLine": 3790,
-                                    "startColumn": 4
+                                    "endLine": 3790,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -2704,7 +2910,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3790,
-                                                        "startColumn": 4
+                                                        "endLine": 3790,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -2734,7 +2942,9 @@
                                 },
                                 "region": {
                                     "startLine": 3833,
-                                    "startColumn": 7
+                                    "endLine": 3833,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -2756,7 +2966,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3833,
-                                                        "startColumn": 7
+                                                        "endLine": 3833,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -2786,7 +2998,9 @@
                                 },
                                 "region": {
                                     "startLine": 3995,
-                                    "startColumn": 6
+                                    "endLine": 3995,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -2808,7 +3022,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3995,
-                                                        "startColumn": 6
+                                                        "endLine": 3995,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -2838,7 +3054,9 @@
                                 },
                                 "region": {
                                     "startLine": 3999,
-                                    "startColumn": 3
+                                    "endLine": 3999,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -2860,7 +3078,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3999,
-                                                        "startColumn": 3
+                                                        "endLine": 3999,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -2890,7 +3110,9 @@
                                 },
                                 "region": {
                                     "startLine": 4002,
-                                    "startColumn": 6
+                                    "endLine": 4002,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -2912,7 +3134,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4002,
-                                                        "startColumn": 6
+                                                        "endLine": 4002,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -2942,7 +3166,9 @@
                                 },
                                 "region": {
                                     "startLine": 464,
-                                    "startColumn": 2
+                                    "endLine": 464,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -2964,7 +3190,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 464,
-                                                        "startColumn": 2
+                                                        "endLine": 464,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -2994,7 +3222,9 @@
                                 },
                                 "region": {
                                     "startLine": 290,
-                                    "startColumn": 5
+                                    "endLine": 290,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -3016,7 +3246,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 290,
-                                                        "startColumn": 5
+                                                        "endLine": 290,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -3046,7 +3278,9 @@
                                 },
                                 "region": {
                                     "startLine": 291,
-                                    "startColumn": 5
+                                    "endLine": 291,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -3068,7 +3302,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 291,
-                                                        "startColumn": 5
+                                                        "endLine": 291,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -3098,7 +3334,9 @@
                                 },
                                 "region": {
                                     "startLine": 660,
-                                    "startColumn": 7
+                                    "endLine": 660,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -3120,7 +3358,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 660,
-                                                        "startColumn": 7
+                                                        "endLine": 660,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -3150,7 +3390,9 @@
                                 },
                                 "region": {
                                     "startLine": 2448,
-                                    "startColumn": 7
+                                    "endLine": 2448,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -3172,7 +3414,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2448,
-                                                        "startColumn": 7
+                                                        "endLine": 2448,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -3202,7 +3446,9 @@
                                 },
                                 "region": {
                                     "startLine": 2452,
-                                    "startColumn": 7
+                                    "endLine": 2452,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -3224,7 +3470,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2452,
-                                                        "startColumn": 7
+                                                        "endLine": 2452,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -3254,7 +3502,9 @@
                                 },
                                 "region": {
                                     "startLine": 82,
-                                    "startColumn": 5
+                                    "endLine": 82,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -3276,7 +3526,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 82,
-                                                        "startColumn": 5
+                                                        "endLine": 82,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -3306,7 +3558,9 @@
                                 },
                                 "region": {
                                     "startLine": 73,
-                                    "startColumn": 5
+                                    "endLine": 73,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -3328,7 +3582,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 73,
-                                                        "startColumn": 5
+                                                        "endLine": 73,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -3358,7 +3614,9 @@
                                 },
                                 "region": {
                                     "startLine": 2242,
-                                    "startColumn": 4
+                                    "endLine": 2242,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -3380,7 +3638,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2242,
-                                                        "startColumn": 4
+                                                        "endLine": 2242,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -3410,7 +3670,9 @@
                                 },
                                 "region": {
                                     "startLine": 2828,
-                                    "startColumn": 5
+                                    "endLine": 2828,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -3432,7 +3694,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2828,
-                                                        "startColumn": 5
+                                                        "endLine": 2828,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -3462,7 +3726,9 @@
                                 },
                                 "region": {
                                     "startLine": 2832,
-                                    "startColumn": 5
+                                    "endLine": 2832,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -3484,7 +3750,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2832,
-                                                        "startColumn": 5
+                                                        "endLine": 2832,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -3514,7 +3782,9 @@
                                 },
                                 "region": {
                                     "startLine": 3262,
-                                    "startColumn": 2
+                                    "endLine": 3262,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -3536,7 +3806,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3262,
-                                                        "startColumn": 2
+                                                        "endLine": 3262,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -3566,7 +3838,9 @@
                                 },
                                 "region": {
                                     "startLine": 3266,
-                                    "startColumn": 6
+                                    "endLine": 3266,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -3588,7 +3862,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3266,
-                                                        "startColumn": 6
+                                                        "endLine": 3266,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -3618,7 +3894,9 @@
                                 },
                                 "region": {
                                     "startLine": 3268,
-                                    "startColumn": 6
+                                    "endLine": 3268,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -3640,7 +3918,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3268,
-                                                        "startColumn": 6
+                                                        "endLine": 3268,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -3670,7 +3950,9 @@
                                 },
                                 "region": {
                                     "startLine": 3323,
-                                    "startColumn": 7
+                                    "endLine": 3323,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -3692,7 +3974,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3323,
-                                                        "startColumn": 7
+                                                        "endLine": 3323,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -3722,7 +4006,9 @@
                                 },
                                 "region": {
                                     "startLine": 3383,
-                                    "startColumn": 6
+                                    "endLine": 3383,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -3744,7 +4030,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3383,
-                                                        "startColumn": 6
+                                                        "endLine": 3383,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -3774,7 +4062,9 @@
                                 },
                                 "region": {
                                     "startLine": 3387,
-                                    "startColumn": 6
+                                    "endLine": 3387,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -3796,7 +4086,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3387,
-                                                        "startColumn": 6
+                                                        "endLine": 3387,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -3826,7 +4118,9 @@
                                 },
                                 "region": {
                                     "startLine": 3430,
-                                    "startColumn": 3
+                                    "endLine": 3430,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -3848,7 +4142,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3430,
-                                                        "startColumn": 3
+                                                        "endLine": 3430,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -3878,7 +4174,9 @@
                                 },
                                 "region": {
                                     "startLine": 3467,
-                                    "startColumn": 8
+                                    "endLine": 3467,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -3900,7 +4198,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3467,
-                                                        "startColumn": 8
+                                                        "endLine": 3467,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -3930,7 +4230,9 @@
                                 },
                                 "region": {
                                     "startLine": 3483,
-                                    "startColumn": 4
+                                    "endLine": 3483,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -3952,7 +4254,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3483,
-                                                        "startColumn": 4
+                                                        "endLine": 3483,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -3982,7 +4286,9 @@
                                 },
                                 "region": {
                                     "startLine": 3541,
-                                    "startColumn": 8
+                                    "endLine": 3541,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -4004,7 +4310,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3541,
-                                                        "startColumn": 8
+                                                        "endLine": 3541,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -4034,7 +4342,9 @@
                                 },
                                 "region": {
                                     "startLine": 3584,
-                                    "startColumn": 9
+                                    "endLine": 3584,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -4056,7 +4366,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3584,
-                                                        "startColumn": 9
+                                                        "endLine": 3584,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -4086,7 +4398,9 @@
                                 },
                                 "region": {
                                     "startLine": 110,
-                                    "startColumn": 6
+                                    "endLine": 110,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -4108,7 +4422,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 110,
-                                                        "startColumn": 6
+                                                        "endLine": 110,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -4138,7 +4454,9 @@
                                 },
                                 "region": {
                                     "startLine": 557,
-                                    "startColumn": 2
+                                    "endLine": 557,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -4160,7 +4478,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 557,
-                                                        "startColumn": 2
+                                                        "endLine": 557,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -4190,7 +4510,9 @@
                                 },
                                 "region": {
                                     "startLine": 3026,
-                                    "startColumn": 5
+                                    "endLine": 3026,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -4212,7 +4534,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3026,
-                                                        "startColumn": 5
+                                                        "endLine": 3026,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -4242,7 +4566,9 @@
                                 },
                                 "region": {
                                     "startLine": 2240,
-                                    "startColumn": 13
+                                    "endLine": 2240,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -4264,7 +4590,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2240,
-                                                        "startColumn": 13
+                                                        "endLine": 2240,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -4294,7 +4622,9 @@
                                 },
                                 "region": {
                                     "startLine": 2242,
-                                    "startColumn": 13
+                                    "endLine": 2242,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -4316,7 +4646,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2242,
-                                                        "startColumn": 13
+                                                        "endLine": 2242,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -4346,7 +4678,9 @@
                                 },
                                 "region": {
                                     "startLine": 203,
-                                    "startColumn": 12
+                                    "endLine": 203,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -4368,7 +4702,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 203,
-                                                        "startColumn": 12
+                                                        "endLine": 203,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -4398,7 +4734,9 @@
                                 },
                                 "region": {
                                     "startLine": 512,
-                                    "startColumn": 2
+                                    "endLine": 512,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -4420,7 +4758,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 512,
-                                                        "startColumn": 2
+                                                        "endLine": 512,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -4450,7 +4790,9 @@
                                 },
                                 "region": {
                                     "startLine": 1413,
-                                    "startColumn": 5
+                                    "endLine": 1413,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -4472,7 +4814,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1413,
-                                                        "startColumn": 5
+                                                        "endLine": 1413,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -4502,7 +4846,9 @@
                                 },
                                 "region": {
                                     "startLine": 1414,
-                                    "startColumn": 5
+                                    "endLine": 1414,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -4524,7 +4870,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1414,
-                                                        "startColumn": 5
+                                                        "endLine": 1414,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -4554,7 +4902,9 @@
                                 },
                                 "region": {
                                     "startLine": 233,
-                                    "startColumn": 6
+                                    "endLine": 233,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -4576,7 +4926,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 233,
-                                                        "startColumn": 6
+                                                        "endLine": 233,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -4606,7 +4958,9 @@
                                 },
                                 "region": {
                                     "startLine": 272,
-                                    "startColumn": 7
+                                    "endLine": 272,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -4628,7 +4982,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 272,
-                                                        "startColumn": 7
+                                                        "endLine": 272,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -4658,7 +5014,9 @@
                                 },
                                 "region": {
                                     "startLine": 418,
-                                    "startColumn": 3
+                                    "endLine": 418,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -4680,7 +5038,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 418,
-                                                        "startColumn": 3
+                                                        "endLine": 418,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -4710,7 +5070,9 @@
                                 },
                                 "region": {
                                     "startLine": 420,
-                                    "startColumn": 3
+                                    "endLine": 420,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -4732,7 +5094,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 420,
-                                                        "startColumn": 3
+                                                        "endLine": 420,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -4762,7 +5126,9 @@
                                 },
                                 "region": {
                                     "startLine": 496,
-                                    "startColumn": 8
+                                    "endLine": 496,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -4784,7 +5150,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 496,
-                                                        "startColumn": 8
+                                                        "endLine": 496,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -4814,7 +5182,9 @@
                                 },
                                 "region": {
                                     "startLine": 498,
-                                    "startColumn": 8
+                                    "endLine": 498,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -4836,7 +5206,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 498,
-                                                        "startColumn": 8
+                                                        "endLine": 498,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -4866,7 +5238,9 @@
                                 },
                                 "region": {
                                     "startLine": 1260,
-                                    "startColumn": 2
+                                    "endLine": 1260,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -4888,7 +5262,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1260,
-                                                        "startColumn": 2
+                                                        "endLine": 1260,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -4918,7 +5294,9 @@
                                 },
                                 "region": {
                                     "startLine": 48,
-                                    "startColumn": 2
+                                    "endLine": 48,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -4940,7 +5318,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 48,
-                                                        "startColumn": 2
+                                                        "endLine": 48,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -4970,7 +5350,9 @@
                                 },
                                 "region": {
                                     "startLine": 50,
-                                    "startColumn": 2
+                                    "endLine": 50,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -4992,7 +5374,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 50,
-                                                        "startColumn": 2
+                                                        "endLine": 50,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -5022,7 +5406,9 @@
                                 },
                                 "region": {
                                     "startLine": 446,
-                                    "startColumn": 6
+                                    "endLine": 446,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -5044,7 +5430,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 446,
-                                                        "startColumn": 6
+                                                        "endLine": 446,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -5074,7 +5462,9 @@
                                 },
                                 "region": {
                                     "startLine": 4223,
-                                    "startColumn": 5
+                                    "endLine": 4223,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -5096,7 +5486,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4223,
-                                                        "startColumn": 5
+                                                        "endLine": 4223,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -5126,7 +5518,9 @@
                                 },
                                 "region": {
                                     "startLine": 2322,
-                                    "startColumn": 3
+                                    "endLine": 2322,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -5148,7 +5542,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2322,
-                                                        "startColumn": 3
+                                                        "endLine": 2322,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -5178,7 +5574,9 @@
                                 },
                                 "region": {
                                     "startLine": 2401,
-                                    "startColumn": 3
+                                    "endLine": 2401,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -5200,7 +5598,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2401,
-                                                        "startColumn": 3
+                                                        "endLine": 2401,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -5230,7 +5630,9 @@
                                 },
                                 "region": {
                                     "startLine": 2484,
-                                    "startColumn": 2
+                                    "endLine": 2484,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -5252,7 +5654,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2484,
-                                                        "startColumn": 2
+                                                        "endLine": 2484,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -5282,7 +5686,9 @@
                                 },
                                 "region": {
                                     "startLine": 3433,
-                                    "startColumn": 3
+                                    "endLine": 3433,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -5304,7 +5710,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3433,
-                                                        "startColumn": 3
+                                                        "endLine": 3433,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -5334,7 +5742,9 @@
                                 },
                                 "region": {
                                     "startLine": 724,
-                                    "startColumn": 3
+                                    "endLine": 724,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -5356,7 +5766,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 724,
-                                                        "startColumn": 3
+                                                        "endLine": 724,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -5386,7 +5798,9 @@
                                 },
                                 "region": {
                                     "startLine": 733,
-                                    "startColumn": 3
+                                    "endLine": 733,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -5408,7 +5822,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 733,
-                                                        "startColumn": 3
+                                                        "endLine": 733,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -5438,7 +5854,9 @@
                                 },
                                 "region": {
                                     "startLine": 846,
-                                    "startColumn": 7
+                                    "endLine": 846,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -5460,7 +5878,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 846,
-                                                        "startColumn": 7
+                                                        "endLine": 846,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -5490,7 +5910,9 @@
                                 },
                                 "region": {
                                     "startLine": 858,
-                                    "startColumn": 3
+                                    "endLine": 858,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -5512,7 +5934,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 858,
-                                                        "startColumn": 3
+                                                        "endLine": 858,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -5542,7 +5966,9 @@
                                 },
                                 "region": {
                                     "startLine": 1787,
-                                    "startColumn": 18
+                                    "endLine": 1787,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -5564,7 +5990,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1787,
-                                                        "startColumn": 18
+                                                        "endLine": 1787,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -5594,7 +6022,9 @@
                                 },
                                 "region": {
                                     "startLine": 2113,
-                                    "startColumn": 9
+                                    "endLine": 2113,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -5616,7 +6046,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2113,
-                                                        "startColumn": 9
+                                                        "endLine": 2113,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -5646,7 +6078,9 @@
                                 },
                                 "region": {
                                     "startLine": 3463,
-                                    "startColumn": 6
+                                    "endLine": 3463,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -5668,7 +6102,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3463,
-                                                        "startColumn": 6
+                                                        "endLine": 3463,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -5698,7 +6134,9 @@
                                 },
                                 "region": {
                                     "startLine": 1025,
-                                    "startColumn": 6
+                                    "endLine": 1025,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -5720,7 +6158,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1025,
-                                                        "startColumn": 6
+                                                        "endLine": 1025,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -5750,7 +6190,9 @@
                                 },
                                 "region": {
                                     "startLine": 1198,
-                                    "startColumn": 4
+                                    "endLine": 1198,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -5772,7 +6214,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1198,
-                                                        "startColumn": 4
+                                                        "endLine": 1198,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -5802,7 +6246,9 @@
                                 },
                                 "region": {
                                     "startLine": 1205,
-                                    "startColumn": 4
+                                    "endLine": 1205,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -5824,7 +6270,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1205,
-                                                        "startColumn": 4
+                                                        "endLine": 1205,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -5854,7 +6302,9 @@
                                 },
                                 "region": {
                                     "startLine": 1207,
-                                    "startColumn": 4
+                                    "endLine": 1207,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -5876,7 +6326,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1207,
-                                                        "startColumn": 4
+                                                        "endLine": 1207,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -5906,7 +6358,9 @@
                                 },
                                 "region": {
                                     "startLine": 1213,
-                                    "startColumn": 4
+                                    "endLine": 1213,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -5928,7 +6382,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1213,
-                                                        "startColumn": 4
+                                                        "endLine": 1213,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -5958,7 +6414,9 @@
                                 },
                                 "region": {
                                     "startLine": 1219,
-                                    "startColumn": 4
+                                    "endLine": 1219,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -5980,7 +6438,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1219,
-                                                        "startColumn": 4
+                                                        "endLine": 1219,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -6010,7 +6470,9 @@
                                 },
                                 "region": {
                                     "startLine": 1220,
-                                    "startColumn": 4
+                                    "endLine": 1220,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -6032,7 +6494,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1220,
-                                                        "startColumn": 4
+                                                        "endLine": 1220,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -6062,7 +6526,9 @@
                                 },
                                 "region": {
                                     "startLine": 1229,
-                                    "startColumn": 8
+                                    "endLine": 1229,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -6084,7 +6550,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1229,
-                                                        "startColumn": 8
+                                                        "endLine": 1229,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -6114,7 +6582,9 @@
                                 },
                                 "region": {
                                     "startLine": 1241,
-                                    "startColumn": 8
+                                    "endLine": 1241,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -6136,7 +6606,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1241,
-                                                        "startColumn": 8
+                                                        "endLine": 1241,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -6166,7 +6638,9 @@
                                 },
                                 "region": {
                                     "startLine": 2561,
-                                    "startColumn": 21
+                                    "endLine": 2561,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -6188,7 +6662,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2561,
-                                                        "startColumn": 21
+                                                        "endLine": 2561,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -6218,7 +6694,9 @@
                                 },
                                 "region": {
                                     "startLine": 505,
-                                    "startColumn": 6
+                                    "endLine": 505,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6240,7 +6718,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 505,
-                                                        "startColumn": 6
+                                                        "endLine": 505,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6270,7 +6750,9 @@
                                 },
                                 "region": {
                                     "startLine": 1069,
-                                    "startColumn": 7
+                                    "endLine": 1069,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -6292,7 +6774,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1069,
-                                                        "startColumn": 7
+                                                        "endLine": 1069,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -6322,7 +6806,9 @@
                                 },
                                 "region": {
                                     "startLine": 1102,
-                                    "startColumn": 7
+                                    "endLine": 1102,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -6344,7 +6830,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1102,
-                                                        "startColumn": 7
+                                                        "endLine": 1102,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -6374,7 +6862,9 @@
                                 },
                                 "region": {
                                     "startLine": 664,
-                                    "startColumn": 2
+                                    "endLine": 664,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -6396,7 +6886,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 664,
-                                                        "startColumn": 2
+                                                        "endLine": 664,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -6426,7 +6918,9 @@
                                 },
                                 "region": {
                                     "startLine": 696,
-                                    "startColumn": 2
+                                    "endLine": 696,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -6448,7 +6942,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 696,
-                                                        "startColumn": 2
+                                                        "endLine": 696,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -6478,7 +6974,9 @@
                                 },
                                 "region": {
                                     "startLine": 735,
-                                    "startColumn": 6
+                                    "endLine": 735,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6500,7 +6998,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 735,
-                                                        "startColumn": 6
+                                                        "endLine": 735,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6530,7 +7030,9 @@
                                 },
                                 "region": {
                                     "startLine": 759,
-                                    "startColumn": 6
+                                    "endLine": 759,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6552,7 +7054,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 759,
-                                                        "startColumn": 6
+                                                        "endLine": 759,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6582,7 +7086,9 @@
                                 },
                                 "region": {
                                     "startLine": 1357,
-                                    "startColumn": 3
+                                    "endLine": 1357,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -6604,7 +7110,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1357,
-                                                        "startColumn": 3
+                                                        "endLine": 1357,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -6634,7 +7142,9 @@
                                 },
                                 "region": {
                                     "startLine": 1363,
-                                    "startColumn": 6
+                                    "endLine": 1363,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6656,7 +7166,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1363,
-                                                        "startColumn": 6
+                                                        "endLine": 1363,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6686,7 +7198,9 @@
                                 },
                                 "region": {
                                     "startLine": 1368,
-                                    "startColumn": 2
+                                    "endLine": 1368,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -6708,7 +7222,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1368,
-                                                        "startColumn": 2
+                                                        "endLine": 1368,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -6738,7 +7254,9 @@
                                 },
                                 "region": {
                                     "startLine": 652,
-                                    "startColumn": 5
+                                    "endLine": 652,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -6760,7 +7278,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 652,
-                                                        "startColumn": 5
+                                                        "endLine": 652,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -6790,7 +7310,9 @@
                                 },
                                 "region": {
                                     "startLine": 104,
-                                    "startColumn": 2
+                                    "endLine": 104,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -6812,7 +7334,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 104,
-                                                        "startColumn": 2
+                                                        "endLine": 104,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -6842,7 +7366,9 @@
                                 },
                                 "region": {
                                     "startLine": 107,
-                                    "startColumn": 2
+                                    "endLine": 107,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -6864,7 +7390,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 107,
-                                                        "startColumn": 2
+                                                        "endLine": 107,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -6894,7 +7422,9 @@
                                 },
                                 "region": {
                                     "startLine": 2586,
-                                    "startColumn": 4
+                                    "endLine": 2586,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -6916,7 +7446,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2586,
-                                                        "startColumn": 4
+                                                        "endLine": 2586,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -6946,7 +7478,9 @@
                                 },
                                 "region": {
                                     "startLine": 2591,
-                                    "startColumn": 4
+                                    "endLine": 2591,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -6968,7 +7502,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2591,
-                                                        "startColumn": 4
+                                                        "endLine": 2591,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -6998,7 +7534,9 @@
                                 },
                                 "region": {
                                     "startLine": 3301,
-                                    "startColumn": 2
+                                    "endLine": 3301,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7020,7 +7558,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3301,
-                                                        "startColumn": 2
+                                                        "endLine": 3301,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7050,7 +7590,9 @@
                                 },
                                 "region": {
                                     "startLine": 116,
-                                    "startColumn": 6
+                                    "endLine": 116,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -7072,7 +7614,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 116,
-                                                        "startColumn": 6
+                                                        "endLine": 116,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -7102,7 +7646,9 @@
                                 },
                                 "region": {
                                     "startLine": 844,
-                                    "startColumn": 2
+                                    "endLine": 844,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7124,7 +7670,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 844,
-                                                        "startColumn": 2
+                                                        "endLine": 844,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7154,7 +7702,9 @@
                                 },
                                 "region": {
                                     "startLine": 848,
-                                    "startColumn": 5
+                                    "endLine": 848,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -7176,7 +7726,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 848,
-                                                        "startColumn": 5
+                                                        "endLine": 848,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -7206,7 +7758,9 @@
                                 },
                                 "region": {
                                     "startLine": 50,
-                                    "startColumn": 2
+                                    "endLine": 50,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7228,7 +7782,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 50,
-                                                        "startColumn": 2
+                                                        "endLine": 50,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7258,7 +7814,9 @@
                                 },
                                 "region": {
                                     "startLine": 135,
-                                    "startColumn": 2
+                                    "endLine": 135,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7280,7 +7838,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 135,
-                                                        "startColumn": 2
+                                                        "endLine": 135,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7310,7 +7870,9 @@
                                 },
                                 "region": {
                                     "startLine": 151,
-                                    "startColumn": 6
+                                    "endLine": 151,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -7332,7 +7894,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 151,
-                                                        "startColumn": 6
+                                                        "endLine": 151,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -7362,7 +7926,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 2
+                                    "endLine": 164,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7384,7 +7950,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 2
+                                                        "endLine": 164,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7414,7 +7982,9 @@
                                 },
                                 "region": {
                                     "startLine": 180,
-                                    "startColumn": 6
+                                    "endLine": 180,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -7436,7 +8006,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 180,
-                                                        "startColumn": 6
+                                                        "endLine": 180,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -7466,7 +8038,9 @@
                                 },
                                 "region": {
                                     "startLine": 194,
-                                    "startColumn": 2
+                                    "endLine": 194,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7488,7 +8062,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 194,
-                                                        "startColumn": 2
+                                                        "endLine": 194,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7518,7 +8094,9 @@
                                 },
                                 "region": {
                                     "startLine": 213,
-                                    "startColumn": 5
+                                    "endLine": 213,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -7540,7 +8118,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 213,
-                                                        "startColumn": 5
+                                                        "endLine": 213,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -7570,7 +8150,9 @@
                                 },
                                 "region": {
                                     "startLine": 239,
-                                    "startColumn": 2
+                                    "endLine": 239,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7592,7 +8174,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 239,
-                                                        "startColumn": 2
+                                                        "endLine": 239,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7622,7 +8206,9 @@
                                 },
                                 "region": {
                                     "startLine": 438,
-                                    "startColumn": 2
+                                    "endLine": 438,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7644,7 +8230,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 438,
-                                                        "startColumn": 2
+                                                        "endLine": 438,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7674,7 +8262,9 @@
                                 },
                                 "region": {
                                     "startLine": 2550,
-                                    "startColumn": 4
+                                    "endLine": 2550,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -7696,7 +8286,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2550,
-                                                        "startColumn": 4
+                                                        "endLine": 2550,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -7726,7 +8318,9 @@
                                 },
                                 "region": {
                                     "startLine": 2554,
-                                    "startColumn": 4
+                                    "endLine": 2554,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -7748,7 +8342,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2554,
-                                                        "startColumn": 4
+                                                        "endLine": 2554,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -7778,7 +8374,9 @@
                                 },
                                 "region": {
                                     "startLine": 2558,
-                                    "startColumn": 4
+                                    "endLine": 2558,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -7800,7 +8398,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2558,
-                                                        "startColumn": 4
+                                                        "endLine": 2558,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -7830,7 +8430,9 @@
                                 },
                                 "region": {
                                     "startLine": 2562,
-                                    "startColumn": 7
+                                    "endLine": 2562,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -7852,7 +8454,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2562,
-                                                        "startColumn": 7
+                                                        "endLine": 2562,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -7882,7 +8486,9 @@
                                 },
                                 "region": {
                                     "startLine": 2873,
-                                    "startColumn": 5
+                                    "endLine": 2873,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -7904,7 +8510,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2873,
-                                                        "startColumn": 5
+                                                        "endLine": 2873,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -7934,7 +8542,9 @@
                                 },
                                 "region": {
                                     "startLine": 2879,
-                                    "startColumn": 6
+                                    "endLine": 2879,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -7956,7 +8566,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2879,
-                                                        "startColumn": 6
+                                                        "endLine": 2879,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -7986,7 +8598,9 @@
                                 },
                                 "region": {
                                     "startLine": 1361,
-                                    "startColumn": 6
+                                    "endLine": 1361,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -8008,7 +8622,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1361,
-                                                        "startColumn": 6
+                                                        "endLine": 1361,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -8038,7 +8654,9 @@
                                 },
                                 "region": {
                                     "startLine": 1511,
-                                    "startColumn": 2
+                                    "endLine": 1511,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8060,7 +8678,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1511,
-                                                        "startColumn": 2
+                                                        "endLine": 1511,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8090,7 +8710,9 @@
                                 },
                                 "region": {
                                     "startLine": 3596,
-                                    "startColumn": 2
+                                    "endLine": 3596,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8112,7 +8734,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3596,
-                                                        "startColumn": 2
+                                                        "endLine": 3596,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8142,7 +8766,9 @@
                                 },
                                 "region": {
                                     "startLine": 229,
-                                    "startColumn": 5
+                                    "endLine": 229,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -8164,7 +8790,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 229,
-                                                        "startColumn": 5
+                                                        "endLine": 229,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -8194,7 +8822,9 @@
                                 },
                                 "region": {
                                     "startLine": 231,
-                                    "startColumn": 5
+                                    "endLine": 231,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -8216,7 +8846,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 231,
-                                                        "startColumn": 5
+                                                        "endLine": 231,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -8246,7 +8878,9 @@
                                 },
                                 "region": {
                                     "startLine": 359,
-                                    "startColumn": 2
+                                    "endLine": 359,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8268,7 +8902,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 359,
-                                                        "startColumn": 2
+                                                        "endLine": 359,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8298,7 +8934,9 @@
                                 },
                                 "region": {
                                     "startLine": 366,
-                                    "startColumn": 2
+                                    "endLine": 366,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8320,7 +8958,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 366,
-                                                        "startColumn": 2
+                                                        "endLine": 366,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8350,7 +8990,9 @@
                                 },
                                 "region": {
                                     "startLine": 2321,
-                                    "startColumn": 3
+                                    "endLine": 2321,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -8372,7 +9014,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2321,
-                                                        "startColumn": 3
+                                                        "endLine": 2321,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -8402,7 +9046,9 @@
                                 },
                                 "region": {
                                     "startLine": 2399,
-                                    "startColumn": 3
+                                    "endLine": 2399,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -8424,7 +9070,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2399,
-                                                        "startColumn": 3
+                                                        "endLine": 2399,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -8454,7 +9102,9 @@
                                 },
                                 "region": {
                                     "startLine": 2579,
-                                    "startColumn": 2
+                                    "endLine": 2579,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8476,7 +9126,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2579,
-                                                        "startColumn": 2
+                                                        "endLine": 2579,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8506,7 +9158,9 @@
                                 },
                                 "region": {
                                     "startLine": 2584,
-                                    "startColumn": 2
+                                    "endLine": 2584,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8528,7 +9182,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2584,
-                                                        "startColumn": 2
+                                                        "endLine": 2584,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8558,7 +9214,9 @@
                                 },
                                 "region": {
                                     "startLine": 2590,
-                                    "startColumn": 2
+                                    "endLine": 2590,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8580,7 +9238,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2590,
-                                                        "startColumn": 2
+                                                        "endLine": 2590,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8610,7 +9270,9 @@
                                 },
                                 "region": {
                                     "startLine": 521,
-                                    "startColumn": 2
+                                    "endLine": 521,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8632,7 +9294,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 521,
-                                                        "startColumn": 2
+                                                        "endLine": 521,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8662,7 +9326,9 @@
                                 },
                                 "region": {
                                     "startLine": 1286,
-                                    "startColumn": 2
+                                    "endLine": 1286,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8684,7 +9350,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1286,
-                                                        "startColumn": 2
+                                                        "endLine": 1286,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8714,7 +9382,9 @@
                                 },
                                 "region": {
                                     "startLine": 3767,
-                                    "startColumn": 2
+                                    "endLine": 3767,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -8736,7 +9406,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3767,
-                                                        "startColumn": 2
+                                                        "endLine": 3767,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -8766,7 +9438,9 @@
                                 },
                                 "region": {
                                     "startLine": 3891,
-                                    "startColumn": 7
+                                    "endLine": 3891,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -8788,7 +9462,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3891,
-                                                        "startColumn": 7
+                                                        "endLine": 3891,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -8818,7 +9494,9 @@
                                 },
                                 "region": {
                                     "startLine": 1231,
-                                    "startColumn": 7
+                                    "endLine": 1231,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -8840,7 +9518,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 1231,
-                                                        "startColumn": 7
+                                                        "endLine": 1231,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {

--- a/tests/csgrep/0082-sarif-parser-stdout.txt
+++ b/tests/csgrep/0082-sarif-parser-stdout.txt
@@ -12,6 +12,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 1806,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -27,6 +28,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 1866,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -42,6 +44,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2102,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -57,6 +60,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2109,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -72,6 +76,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2122,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -87,6 +92,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 554,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -102,6 +108,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1160,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -117,6 +124,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1167,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -132,6 +140,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1669,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -147,6 +156,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1988,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -162,6 +172,7 @@
                     "file_name": "Src/Modules/zutil.c",
                     "line": 1998,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -177,6 +188,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2911,
                     "column": 13,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -192,6 +204,7 @@
                     "file_name": "Src/string.c",
                     "line": 40,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -207,6 +220,7 @@
                     "file_name": "Src/string.c",
                     "line": 71,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -222,6 +236,7 @@
                     "file_name": "Src/string.c",
                     "line": 84,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -237,6 +252,7 @@
                     "file_name": "Src/string.c",
                     "line": 121,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -252,6 +268,7 @@
                     "file_name": "Src/string.c",
                     "line": 122,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -267,6 +284,7 @@
                     "file_name": "Src/string.c",
                     "line": 123,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -282,6 +300,7 @@
                     "file_name": "Src/string.c",
                     "line": 136,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -297,6 +316,7 @@
                     "file_name": "Src/string.c",
                     "line": 137,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -312,6 +332,7 @@
                     "file_name": "Src/string.c",
                     "line": 138,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -327,6 +348,7 @@
                     "file_name": "Src/string.c",
                     "line": 153,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -342,6 +364,7 @@
                     "file_name": "Src/string.c",
                     "line": 154,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -357,6 +380,7 @@
                     "file_name": "Src/string.c",
                     "line": 167,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -372,6 +396,7 @@
                     "file_name": "Src/string.c",
                     "line": 168,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -387,6 +412,7 @@
                     "file_name": "Src/parse.c",
                     "line": 3332,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -402,6 +428,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1412,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -417,6 +444,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1565,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -432,6 +460,7 @@
                     "file_name": "Src/Zle/zle_hist.c",
                     "line": 1640,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -447,6 +476,7 @@
                     "file_name": "Src/Zle/zle_hist.c",
                     "line": 1903,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -462,6 +492,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 231,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -477,6 +508,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 270,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -492,6 +524,7 @@
                     "file_name": "Src/hashtable.c",
                     "line": 666,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -507,6 +540,7 @@
                     "file_name": "Src/hist.c",
                     "line": 2380,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -522,6 +556,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 682,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -537,6 +572,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 943,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -552,6 +588,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 959,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -567,6 +604,7 @@
                     "file_name": "Src/Zle/zle_tricky.c",
                     "line": 2848,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -582,6 +620,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 841,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -597,6 +636,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1242,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -612,6 +652,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1339,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -627,6 +668,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1404,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -642,6 +684,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 1410,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -657,6 +700,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 1461,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -672,6 +716,7 @@
                     "file_name": "Src/subst.c",
                     "line": 417,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -687,6 +732,7 @@
                     "file_name": "Src/subst.c",
                     "line": 418,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -702,6 +748,7 @@
                     "file_name": "Src/subst.c",
                     "line": 427,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -717,6 +764,7 @@
                     "file_name": "Src/subst.c",
                     "line": 428,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -732,6 +780,7 @@
                     "file_name": "Src/subst.c",
                     "line": 429,
                     "column": 12,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -747,6 +796,7 @@
                     "file_name": "Src/subst.c",
                     "line": 828,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -762,6 +812,7 @@
                     "file_name": "Src/subst.c",
                     "line": 833,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -777,6 +828,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3790,
                     "column": 4,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -792,6 +844,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3833,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -807,6 +860,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3995,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -822,6 +876,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3999,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -837,6 +892,7 @@
                     "file_name": "Src/subst.c",
                     "line": 4002,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -852,6 +908,7 @@
                     "file_name": "Src/input.c",
                     "line": 464,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -867,6 +924,7 @@
                     "file_name": "Src/glob.c",
                     "line": 290,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -882,6 +940,7 @@
                     "file_name": "Src/glob.c",
                     "line": 291,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -897,6 +956,7 @@
                     "file_name": "Src/glob.c",
                     "line": 660,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -912,6 +972,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2448,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -927,6 +988,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2452,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -942,6 +1004,7 @@
                     "file_name": "Src/Modules/tcp.c",
                     "line": 82,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -957,6 +1020,7 @@
                     "file_name": "Src/compat.c",
                     "line": 73,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -972,6 +1036,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 2242,
                     "column": 4,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -987,6 +1052,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 2828,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1002,6 +1068,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 2832,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1017,6 +1084,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3262,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1032,6 +1100,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3266,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1047,6 +1116,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3268,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1062,6 +1132,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3323,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1077,6 +1148,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3383,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1092,6 +1164,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3387,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1107,6 +1180,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3430,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1122,6 +1196,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3467,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1137,6 +1212,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3483,
                     "column": 4,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1152,6 +1228,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3541,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1167,6 +1244,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3584,
                     "column": 9,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1182,6 +1260,7 @@
                     "file_name": "Src/Zle/zle_vi.c",
                     "line": 110,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1197,6 +1276,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 557,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1212,6 +1292,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 3026,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1227,6 +1308,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2240,
                     "column": 13,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1242,6 +1324,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2242,
                     "column": 13,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1257,6 +1340,7 @@
                     "file_name": "Src/string.c",
                     "line": 203,
                     "column": 12,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1272,6 +1356,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 512,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1287,6 +1372,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1413,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1302,6 +1388,7 @@
                     "file_name": "Src/Zle/compcore.c",
                     "line": 1414,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1317,6 +1404,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 233,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1332,6 +1420,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 272,
                     "column": 7,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1347,6 +1436,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 418,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1362,6 +1452,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 420,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1377,6 +1468,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 496,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1392,6 +1484,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 498,
                     "column": 8,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1407,6 +1500,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1260,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1422,6 +1516,7 @@
                     "file_name": "Src/Zle/zleparameter.c",
                     "line": 48,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1437,6 +1532,7 @@
                     "file_name": "Src/Zle/zleparameter.c",
                     "line": 50,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1452,6 +1548,7 @@
                     "file_name": "Src/Zle/zle_refresh.c",
                     "line": 446,
                     "column": 6,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1467,6 +1564,7 @@
                     "file_name": "Src/subst.c",
                     "line": 4223,
                     "column": 5,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1482,6 +1580,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2322,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1497,6 +1596,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2401,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1512,6 +1612,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2484,
                     "column": 2,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1527,6 +1628,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3433,
                     "column": 3,
+                    "h_size": 5,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1542,6 +1644,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 724,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1557,6 +1660,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 733,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1572,6 +1676,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 846,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1587,6 +1692,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 858,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1602,6 +1708,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 1787,
                     "column": 18,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1617,6 +1724,7 @@
                     "file_name": "Src/prompt.c",
                     "line": 2113,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1632,6 +1740,7 @@
                     "file_name": "Src/module.c",
                     "line": 3463,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1647,6 +1756,7 @@
                     "file_name": "Src/Modules/zftp.c",
                     "line": 1025,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1662,6 +1772,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1198,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1677,6 +1788,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1205,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1692,6 +1804,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1207,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1707,6 +1820,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1213,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1722,6 +1836,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1219,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1737,6 +1852,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1220,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1752,6 +1868,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1229,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1767,6 +1884,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 1241,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1782,6 +1900,7 @@
                     "file_name": "Src/Zle/complist.c",
                     "line": 2561,
                     "column": 21,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1797,6 +1916,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 505,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1812,6 +1932,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 1069,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1827,6 +1948,7 @@
                     "file_name": "Src/Zle/compresult.c",
                     "line": 1102,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1842,6 +1964,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 664,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1857,6 +1980,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 696,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1872,6 +1996,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 735,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1887,6 +2012,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 759,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1902,6 +2028,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1357,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1917,6 +2044,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1363,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1932,6 +2060,7 @@
                     "file_name": "Src/Modules/parameter.c",
                     "line": 1368,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1947,6 +2076,7 @@
                     "file_name": "Src/hashtable.c",
                     "line": 652,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1962,6 +2092,7 @@
                     "file_name": "Src/text.c",
                     "line": 104,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1977,6 +2108,7 @@
                     "file_name": "Src/text.c",
                     "line": 107,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1992,6 +2124,7 @@
                     "file_name": "Src/pattern.c",
                     "line": 2586,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2007,6 +2140,7 @@
                     "file_name": "Src/pattern.c",
                     "line": 2591,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2022,6 +2156,7 @@
                     "file_name": "Src/hist.c",
                     "line": 3301,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2037,6 +2172,7 @@
                     "file_name": "Src/cond.c",
                     "line": 116,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2052,6 +2188,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 844,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2067,6 +2204,7 @@
                     "file_name": "Src/Zle/zle_misc.c",
                     "line": 848,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2082,6 +2220,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 50,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2097,6 +2236,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 135,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2112,6 +2252,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 151,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2127,6 +2268,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 164,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2142,6 +2284,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 180,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2157,6 +2300,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 194,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2172,6 +2316,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 213,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2187,6 +2332,7 @@
                     "file_name": "Src/Modules/stat.c",
                     "line": 239,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2202,6 +2348,7 @@
                     "file_name": "Src/Zle/zle_refresh.c",
                     "line": 438,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2217,6 +2364,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2550,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2232,6 +2380,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2554,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2247,6 +2396,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2558,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2262,6 +2412,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2562,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2277,6 +2428,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2873,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2292,6 +2444,7 @@
                     "file_name": "Src/jobs.c",
                     "line": 2879,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2307,6 +2460,7 @@
                     "file_name": "Src/signals.c",
                     "line": 1361,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2322,6 +2476,7 @@
                     "file_name": "Src/subst.c",
                     "line": 1511,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2337,6 +2492,7 @@
                     "file_name": "Src/subst.c",
                     "line": 3596,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2352,6 +2508,7 @@
                     "file_name": "Src/Modules/datetime.c",
                     "line": 229,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2367,6 +2524,7 @@
                     "file_name": "Src/Modules/datetime.c",
                     "line": 231,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2382,6 +2540,7 @@
                     "file_name": "Src/Builtins/sched.c",
                     "line": 359,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2397,6 +2556,7 @@
                     "file_name": "Src/Builtins/sched.c",
                     "line": 366,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2412,6 +2572,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2321,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2427,6 +2588,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2399,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2442,6 +2604,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2579,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2457,6 +2620,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2584,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2472,6 +2636,7 @@
                     "file_name": "Src/glob.c",
                     "line": 2590,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2487,6 +2652,7 @@
                     "file_name": "Src/Modules/system.c",
                     "line": 521,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2502,6 +2668,7 @@
                     "file_name": "Src/Zle/zle_keymap.c",
                     "line": 1286,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2517,6 +2684,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3767,
                     "column": 2,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2532,6 +2700,7 @@
                     "file_name": "Src/Zle/compctl.c",
                     "line": 3891,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -2547,6 +2716,7 @@
                     "file_name": "Src/Modules/curses.c",
                     "line": 1231,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0

--- a/tests/csgrep/0085-sarif-writer-stdout.txt
+++ b/tests/csgrep/0085-sarif-writer-stdout.txt
@@ -142,9 +142,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -156,9 +153,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -170,9 +164,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -184,9 +175,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -198,9 +186,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -289,9 +274,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -303,9 +285,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -317,9 +296,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -331,9 +307,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -345,9 +318,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -436,9 +406,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -450,9 +417,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -464,9 +428,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -478,9 +439,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -492,9 +450,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -583,9 +538,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -597,9 +549,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -611,9 +560,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -625,9 +571,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -639,9 +582,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -730,9 +670,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -744,9 +681,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -758,9 +692,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -772,9 +703,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -786,9 +714,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -877,9 +802,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -891,9 +813,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -905,9 +824,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -919,9 +835,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -933,9 +846,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1024,9 +934,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1038,9 +945,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1052,9 +956,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1066,9 +967,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1080,9 +978,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1171,9 +1066,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1185,9 +1077,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1199,9 +1088,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1213,9 +1099,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1227,9 +1110,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1318,9 +1198,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1332,9 +1209,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1346,9 +1220,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1360,9 +1231,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1374,9 +1242,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1465,9 +1330,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1479,9 +1341,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1493,9 +1352,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1507,9 +1363,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1521,9 +1374,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1612,9 +1462,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1626,9 +1473,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1640,9 +1484,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1654,9 +1495,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1668,9 +1506,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1759,9 +1594,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1773,9 +1605,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1787,9 +1616,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1801,9 +1627,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1815,9 +1638,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1906,9 +1726,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1920,9 +1737,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1934,9 +1748,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1948,9 +1759,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -1962,9 +1770,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2053,9 +1858,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2067,9 +1869,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2081,9 +1880,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2095,9 +1891,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2109,9 +1902,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2200,9 +1990,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2214,9 +2001,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2228,9 +2012,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2242,9 +2023,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2256,9 +2034,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2347,9 +2122,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2361,9 +2133,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2375,9 +2144,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2389,9 +2155,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2403,9 +2166,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2494,9 +2254,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2508,9 +2265,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2522,9 +2276,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2536,9 +2287,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2550,9 +2298,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2641,9 +2386,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2655,9 +2397,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2669,9 +2408,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2683,9 +2419,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2697,9 +2430,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2788,9 +2518,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2802,9 +2529,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2816,9 +2540,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2830,9 +2551,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2844,9 +2562,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2935,9 +2650,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2949,9 +2661,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2963,9 +2672,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2977,9 +2683,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -2991,9 +2694,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3082,9 +2782,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3096,9 +2793,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3110,9 +2804,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3124,9 +2815,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3138,9 +2826,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3229,9 +2914,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3243,9 +2925,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3257,9 +2936,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3271,9 +2947,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {
@@ -3285,9 +2958,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": ""
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             },
                             "message": {

--- a/tests/csgrep/0085-sarif-writer-stdout.txt
+++ b/tests/csgrep/0085-sarif-writer-stdout.txt
@@ -76,6 +76,7 @@
                                 },
                                 "region": {
                                     "startLine": 30,
+                                    "endLine": 30,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   28|   #include <boost/program_options.hpp>\n   29|   \n   30|-> int main(int argc, char *argv[])\n   31|   {\n   32|       using std::string;"
                                     }
@@ -99,7 +100,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 30
+                                                        "startLine": 30,
+                                                        "endLine": 30
                                                     }
                                                 },
                                                 "message": {
@@ -119,7 +121,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 122
+                                                        "startLine": 122,
+                                                        "endLine": 122
                                                     }
                                                 },
                                                 "message": {
@@ -208,6 +211,7 @@
                                 },
                                 "region": {
                                     "startLine": 30,
+                                    "endLine": 30,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   28|   #include <boost/program_options.hpp>\n   29|   \n   30|-> int main(int argc, char *argv[])\n   31|   {\n   32|       using std::string;"
                                     }
@@ -231,7 +235,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 30
+                                                        "startLine": 30,
+                                                        "endLine": 30
                                                     }
                                                 },
                                                 "message": {
@@ -251,7 +256,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 169
+                                                        "startLine": 169,
+                                                        "endLine": 169
                                                     }
                                                 },
                                                 "message": {
@@ -340,6 +346,7 @@
                                 },
                                 "region": {
                                     "startLine": 30,
+                                    "endLine": 30,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   28|   #include <boost/program_options.hpp>\n   29|   \n   30|-> int main(int argc, char *argv[])\n   31|   {\n   32|       using std::string;"
                                     }
@@ -363,7 +370,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 30
+                                                        "startLine": 30,
+                                                        "endLine": 30
                                                     }
                                                 },
                                                 "message": {
@@ -383,7 +391,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 124
+                                                        "startLine": 124,
+                                                        "endLine": 124
                                                     }
                                                 },
                                                 "message": {
@@ -472,6 +481,7 @@
                                 },
                                 "region": {
                                     "startLine": 30,
+                                    "endLine": 30,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   28|   #include <boost/program_options.hpp>\n   29|   \n   30|-> int main(int argc, char *argv[])\n   31|   {\n   32|       using std::string;"
                                     }
@@ -495,7 +505,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 30
+                                                        "startLine": 30,
+                                                        "endLine": 30
                                                     }
                                                 },
                                                 "message": {
@@ -515,7 +526,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csdiff.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 126
+                                                        "startLine": 126,
+                                                        "endLine": 126
                                                     }
                                                 },
                                                 "message": {
@@ -604,6 +616,7 @@
                                 },
                                 "region": {
                                     "startLine": 563,
+                                    "endLine": 563,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  561|   }\n  562|   \n  563|-> int main(int argc, char *argv[])\n  564|   {\n  565|       using std::string;"
                                     }
@@ -627,7 +640,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csgrep.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 563
+                                                        "startLine": 563,
+                                                        "endLine": 563
                                                     }
                                                 },
                                                 "message": {
@@ -647,7 +661,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csgrep.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 650
+                                                        "startLine": 650,
+                                                        "endLine": 650
                                                     }
                                                 },
                                                 "message": {
@@ -736,6 +751,7 @@
                                 },
                                 "region": {
                                     "startLine": 563,
+                                    "endLine": 563,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  561|   }\n  562|   \n  563|-> int main(int argc, char *argv[])\n  564|   {\n  565|       using std::string;"
                                     }
@@ -759,7 +775,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csgrep.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 563
+                                                        "startLine": 563,
+                                                        "endLine": 563
                                                     }
                                                 },
                                                 "message": {
@@ -779,7 +796,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csgrep.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 597
+                                                        "startLine": 597,
+                                                        "endLine": 597
                                                     }
                                                 },
                                                 "message": {
@@ -868,6 +886,7 @@
                                 },
                                 "region": {
                                     "startLine": 563,
+                                    "endLine": 563,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  561|   }\n  562|   \n  563|-> int main(int argc, char *argv[])\n  564|   {\n  565|       using std::string;"
                                     }
@@ -891,7 +910,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csgrep.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 563
+                                                        "startLine": 563,
+                                                        "endLine": 563
                                                     }
                                                 },
                                                 "message": {
@@ -911,7 +931,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csgrep.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 651
+                                                        "startLine": 651,
+                                                        "endLine": 651
                                                     }
                                                 },
                                                 "message": {
@@ -1000,6 +1021,7 @@
                                 },
                                 "region": {
                                     "startLine": 54,
+                                    "endLine": 54,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   52|   }\n   53|   \n   54|-> int main(int argc, char *argv[])\n   55|   {\n   56|       using std::string;"
                                     }
@@ -1023,7 +1045,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cshtml.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 54
+                                                        "startLine": 54,
+                                                        "endLine": 54
                                                     }
                                                 },
                                                 "message": {
@@ -1043,7 +1066,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cshtml.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 129
+                                                        "startLine": 129,
+                                                        "endLine": 129
                                                     }
                                                 },
                                                 "message": {
@@ -1132,6 +1156,7 @@
                                 },
                                 "region": {
                                     "startLine": 54,
+                                    "endLine": 54,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   52|   }\n   53|   \n   54|-> int main(int argc, char *argv[])\n   55|   {\n   56|       using std::string;"
                                     }
@@ -1155,7 +1180,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cshtml.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 54
+                                                        "startLine": 54,
+                                                        "endLine": 54
                                                     }
                                                 },
                                                 "message": {
@@ -1175,7 +1201,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cshtml.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 74
+                                                        "startLine": 74,
+                                                        "endLine": 74
                                                     }
                                                 },
                                                 "message": {
@@ -1264,6 +1291,7 @@
                                 },
                                 "region": {
                                     "startLine": 152,
+                                    "endLine": 152,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  150|   }\n  151|   \n  152|-> int main(int argc, char *argv[])\n  153|   {\n  154|       using std::string;"
                                     }
@@ -1287,7 +1315,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 152
+                                                        "startLine": 152,
+                                                        "endLine": 152
                                                     }
                                                 },
                                                 "message": {
@@ -1307,7 +1336,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 209
+                                                        "startLine": 209,
+                                                        "endLine": 209
                                                     }
                                                 },
                                                 "message": {
@@ -1396,6 +1426,7 @@
                                 },
                                 "region": {
                                     "startLine": 152,
+                                    "endLine": 152,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  150|   }\n  151|   \n  152|-> int main(int argc, char *argv[])\n  153|   {\n  154|       using std::string;"
                                     }
@@ -1419,7 +1450,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 152
+                                                        "startLine": 152,
+                                                        "endLine": 152
                                                     }
                                                 },
                                                 "message": {
@@ -1439,7 +1471,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 237
+                                                        "startLine": 237,
+                                                        "endLine": 237
                                                     }
                                                 },
                                                 "message": {
@@ -1528,6 +1561,7 @@
                                 },
                                 "region": {
                                     "startLine": 152,
+                                    "endLine": 152,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  150|   }\n  151|   \n  152|-> int main(int argc, char *argv[])\n  153|   {\n  154|       using std::string;"
                                     }
@@ -1551,7 +1585,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 152
+                                                        "startLine": 152,
+                                                        "endLine": 152
                                                     }
                                                 },
                                                 "message": {
@@ -1571,7 +1606,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 224
+                                                        "startLine": 224,
+                                                        "endLine": 224
                                                     }
                                                 },
                                                 "message": {
@@ -1660,6 +1696,7 @@
                                 },
                                 "region": {
                                     "startLine": 152,
+                                    "endLine": 152,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  150|   }\n  151|   \n  152|-> int main(int argc, char *argv[])\n  153|   {\n  154|       using std::string;"
                                     }
@@ -1683,7 +1720,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 152
+                                                        "startLine": 152,
+                                                        "endLine": 152
                                                     }
                                                 },
                                                 "message": {
@@ -1703,7 +1741,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 229
+                                                        "startLine": 229,
+                                                        "endLine": 229
                                                     }
                                                 },
                                                 "message": {
@@ -1792,6 +1831,7 @@
                                 },
                                 "region": {
                                     "startLine": 152,
+                                    "endLine": 152,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  150|   }\n  151|   \n  152|-> int main(int argc, char *argv[])\n  153|   {\n  154|       using std::string;"
                                     }
@@ -1815,7 +1855,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 152
+                                                        "startLine": 152,
+                                                        "endLine": 152
                                                     }
                                                 },
                                                 "message": {
@@ -1835,7 +1876,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cslinker.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 224
+                                                        "startLine": 224,
+                                                        "endLine": 224
                                                     }
                                                 },
                                                 "message": {
@@ -1924,6 +1966,7 @@
                                 },
                                 "region": {
                                     "startLine": 161,
+                                    "endLine": 161,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  159|   }\n  160|   \n  161|-> int main(int argc, char *argv[])\n  162|   {\n  163|       using std::string;"
                                     }
@@ -1947,7 +1990,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cssort.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 161
+                                                        "startLine": 161,
+                                                        "endLine": 161
                                                     }
                                                 },
                                                 "message": {
@@ -1967,7 +2011,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cssort.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 239
+                                                        "startLine": 239,
+                                                        "endLine": 239
                                                     }
                                                 },
                                                 "message": {
@@ -2056,6 +2101,7 @@
                                 },
                                 "region": {
                                     "startLine": 161,
+                                    "endLine": 161,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  159|   }\n  160|   \n  161|-> int main(int argc, char *argv[])\n  162|   {\n  163|       using std::string;"
                                     }
@@ -2079,7 +2125,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cssort.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 161
+                                                        "startLine": 161,
+                                                        "endLine": 161
                                                     }
                                                 },
                                                 "message": {
@@ -2099,7 +2146,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cssort.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 175
+                                                        "startLine": 175,
+                                                        "endLine": 175
                                                     }
                                                 },
                                                 "message": {
@@ -2188,6 +2236,7 @@
                                 },
                                 "region": {
                                     "startLine": 161,
+                                    "endLine": 161,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  159|   }\n  160|   \n  161|-> int main(int argc, char *argv[])\n  162|   {\n  163|       using std::string;"
                                     }
@@ -2211,7 +2260,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cssort.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 161
+                                                        "startLine": 161,
+                                                        "endLine": 161
                                                     }
                                                 },
                                                 "message": {
@@ -2231,7 +2281,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cssort.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 236
+                                                        "startLine": 236,
+                                                        "endLine": 236
                                                     }
                                                 },
                                                 "message": {
@@ -2320,6 +2371,7 @@
                                 },
                                 "region": {
                                     "startLine": 300,
+                                    "endLine": 300,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  298|   }\n  299|   \n  300|-> int main(int argc, char *argv[])\n  301|   {\n  302|       // used also in diagnostic messages"
                                     }
@@ -2343,7 +2395,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cstrans-df-run.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 300
+                                                        "startLine": 300,
+                                                        "endLine": 300
                                                     }
                                                 },
                                                 "message": {
@@ -2363,7 +2416,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cstrans-df-run.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 358
+                                                        "startLine": 358,
+                                                        "endLine": 358
                                                     }
                                                 },
                                                 "message": {
@@ -2452,6 +2506,7 @@
                                 },
                                 "region": {
                                     "startLine": 300,
+                                    "endLine": 300,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  298|   }\n  299|   \n  300|-> int main(int argc, char *argv[])\n  301|   {\n  302|       // used also in diagnostic messages"
                                     }
@@ -2475,7 +2530,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cstrans-df-run.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 300
+                                                        "startLine": 300,
+                                                        "endLine": 300
                                                     }
                                                 },
                                                 "message": {
@@ -2495,7 +2551,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cstrans-df-run.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 365
+                                                        "startLine": 365,
+                                                        "endLine": 365
                                                     }
                                                 },
                                                 "message": {
@@ -2584,6 +2641,7 @@
                                 },
                                 "region": {
                                     "startLine": 300,
+                                    "endLine": 300,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  298|   }\n  299|   \n  300|-> int main(int argc, char *argv[])\n  301|   {\n  302|       // used also in diagnostic messages"
                                     }
@@ -2607,7 +2665,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cstrans-df-run.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 300
+                                                        "startLine": 300,
+                                                        "endLine": 300
                                                     }
                                                 },
                                                 "message": {
@@ -2627,7 +2686,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/cstrans-df-run.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 369
+                                                        "startLine": 369,
+                                                        "endLine": 369
                                                     }
                                                 },
                                                 "message": {
@@ -2716,6 +2776,7 @@
                                 },
                                 "region": {
                                     "startLine": 36,
+                                    "endLine": 36,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n   34|       d(new Private)\n   35|   {\n   36|-> }\n   37|   \n   38|   AbstractCsvParser::~AbstractCsvParser()"
                                     }
@@ -2739,7 +2800,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csv-parser.hh"
                                                     },
                                                     "region": {
-                                                        "startLine": 44
+                                                        "startLine": 44,
+                                                        "endLine": 44
                                                     }
                                                 },
                                                 "message": {
@@ -2759,7 +2821,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/csv-parser.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 36
+                                                        "startLine": 36,
+                                                        "endLine": 36
                                                     }
                                                 },
                                                 "message": {
@@ -2848,6 +2911,7 @@
                                 },
                                 "region": {
                                     "startLine": 347,
+                                    "endLine": 347,
                                     "snippet": {
                                         "text": "Problem detected in this context:\n  345|           str(str_)\n  346|       {\n  347|->     }\n  348|   };\n  349|   "
                                     }
@@ -2871,7 +2935,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/json-writer.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 342
+                                                        "startLine": 342,
+                                                        "endLine": 342
                                                     }
                                                 },
                                                 "message": {
@@ -2891,7 +2956,8 @@
                                                         "uri": "csdiff-2.3.0.20220405.151039.gdb041e9.sarif/src/json-writer.cc"
                                                     },
                                                     "region": {
-                                                        "startLine": 347
+                                                        "startLine": 347,
+                                                        "endLine": 347
                                                     }
                                                 },
                                                 "message": {

--- a/tests/csgrep/0090-sarif-writer-illegal-utf8-sequence-stdout.txt
+++ b/tests/csgrep/0090-sarif-writer-illegal-utf8-sequence-stdout.txt
@@ -30,9 +30,6 @@
                             "physicalLocation": {
                                 "artifactLocation": {
                                     "uri": "test.c"
-                                },
-                                "region": {
-                                    "startLine": 0
                                 }
                             }
                         }
@@ -51,9 +48,6 @@
                                                 "physicalLocation": {
                                                     "artifactLocation": {
                                                         "uri": "test.c"
-                                                    },
-                                                    "region": {
-                                                        "startLine": 0
                                                     }
                                                 },
                                                 "message": {

--- a/tests/csgrep/0094-gcc-json-stdout.txt
+++ b/tests/csgrep/0094-gcc-json-stdout.txt
@@ -49,7 +49,8 @@
                 {
                     "file_name": "xxx.c",
                     "line": 11,
-                    "column": 15,
+                    "column": 11,
+                    "h_size": 7,
                     "event": "warning[-Wunused-parameter]",
                     "message": "unused parameter ‘argc’",
                     "verbosity_level": 0
@@ -65,7 +66,8 @@
                 {
                     "file_name": "xxx.c",
                     "line": 11,
-                    "column": 27,
+                    "column": 21,
+                    "h_size": 11,
                     "event": "warning[-Wunused-parameter]",
                     "message": "unused parameter ‘argv’",
                     "verbosity_level": 0

--- a/tests/csgrep/0095-gcc-sarif-stdout.txt
+++ b/tests/csgrep/0095-gcc-sarif-stdout.txt
@@ -14,6 +14,7 @@
                     "file_name": "<source>",
                     "line": 7,
                     "column": 5,
+                    "h_size": 9,
                     "event": "warning[-Wanalyzer-double-free]",
                     "message": "double-'free' of 'ptr'",
                     "verbosity_level": 0
@@ -22,6 +23,7 @@
                     "file_name": "<source>",
                     "line": 5,
                     "column": 8,
+                    "h_size": 1,
                     "event": "branch_true",
                     "message": "following 'true' branch (when 'flag != 0')...",
                     "verbosity_level": 1
@@ -30,6 +32,7 @@
                     "file_name": "<source>",
                     "line": 6,
                     "column": 9,
+                    "h_size": 9,
                     "event": "branch_true",
                     "message": "...to here",
                     "verbosity_level": 1
@@ -38,6 +41,7 @@
                     "file_name": "<source>",
                     "line": 6,
                     "column": 9,
+                    "h_size": 9,
                     "event": "release_memory",
                     "message": "first 'free' here",
                     "verbosity_level": 1
@@ -46,6 +50,7 @@
                     "file_name": "<source>",
                     "line": 7,
                     "column": 5,
+                    "h_size": 9,
                     "event": "danger",
                     "message": "second 'free' here; first 'free' was at (3)",
                     "verbosity_level": 1

--- a/tests/csgrep/0096-sarif-levels-stdout.txt
+++ b/tests/csgrep/0096-sarif-levels-stdout.txt
@@ -389,7 +389,9 @@
                                 },
                                 "region": {
                                     "startLine": 6,
-                                    "startColumn": 1
+                                    "endLine": 6,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -411,7 +413,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 6,
-                                                        "startColumn": 1
+                                                        "endLine": 6,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -441,7 +445,9 @@
                                 },
                                 "region": {
                                     "startLine": 4,
-                                    "startColumn": 7
+                                    "endLine": 4,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -463,7 +469,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4,
-                                                        "startColumn": 7
+                                                        "endLine": 4,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -493,7 +501,9 @@
                                 },
                                 "region": {
                                     "startLine": 14,
-                                    "startColumn": 13
+                                    "endLine": 14,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -515,7 +525,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 14,
-                                                        "startColumn": 13
+                                                        "endLine": 14,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -545,7 +557,9 @@
                                 },
                                 "region": {
                                     "startLine": 15,
-                                    "startColumn": 25
+                                    "endLine": 15,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -567,7 +581,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 15,
-                                                        "startColumn": 25
+                                                        "endLine": 15,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -597,7 +613,9 @@
                                 },
                                 "region": {
                                     "startLine": 17,
-                                    "startColumn": 10
+                                    "endLine": 17,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -619,7 +637,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 17,
-                                                        "startColumn": 10
+                                                        "endLine": 17,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -649,7 +669,9 @@
                                 },
                                 "region": {
                                     "startLine": 18,
-                                    "startColumn": 14
+                                    "endLine": 18,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -671,7 +693,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 18,
-                                                        "startColumn": 14
+                                                        "endLine": 18,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -701,7 +725,9 @@
                                 },
                                 "region": {
                                     "startLine": 20,
-                                    "startColumn": 7
+                                    "endLine": 20,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -723,7 +749,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 20,
-                                                        "startColumn": 7
+                                                        "endLine": 20,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -753,7 +781,9 @@
                                 },
                                 "region": {
                                     "startLine": 20,
-                                    "startColumn": 44
+                                    "endLine": 20,
+                                    "startColumn": 44,
+                                    "endColumn": 44
                                 }
                             }
                         }
@@ -775,7 +805,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 20,
-                                                        "startColumn": 44
+                                                        "endLine": 20,
+                                                        "startColumn": 44,
+                                                        "endColumn": 44
                                                     }
                                                 },
                                                 "message": {
@@ -805,7 +837,9 @@
                                 },
                                 "region": {
                                     "startLine": 20,
-                                    "startColumn": 57
+                                    "endLine": 20,
+                                    "startColumn": 57,
+                                    "endColumn": 57
                                 }
                             }
                         }
@@ -827,7 +861,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 20,
-                                                        "startColumn": 57
+                                                        "endLine": 20,
+                                                        "startColumn": 57,
+                                                        "endColumn": 57
                                                     }
                                                 },
                                                 "message": {
@@ -857,7 +893,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 25
+                                    "endLine": 2,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -879,7 +917,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 25
+                                                        "endLine": 2,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -909,7 +949,9 @@
                                 },
                                 "region": {
                                     "startLine": 21,
-                                    "startColumn": 3
+                                    "endLine": 21,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -931,7 +973,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 21,
-                                                        "startColumn": 3
+                                                        "endLine": 21,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -961,7 +1005,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -983,7 +1029,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1013,7 +1061,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1035,7 +1085,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1065,7 +1117,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1087,7 +1141,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1117,7 +1173,9 @@
                                 },
                                 "region": {
                                     "startLine": 6,
-                                    "startColumn": 6
+                                    "endLine": 6,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1139,7 +1197,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 6,
-                                                        "startColumn": 6
+                                                        "endLine": 6,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1169,7 +1229,9 @@
                                 },
                                 "region": {
                                     "startLine": 11,
-                                    "startColumn": 6
+                                    "endLine": 11,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1191,7 +1253,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 11,
-                                                        "startColumn": 6
+                                                        "endLine": 11,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1221,7 +1285,9 @@
                                 },
                                 "region": {
                                     "startLine": 34,
-                                    "startColumn": 7
+                                    "endLine": 34,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -1243,7 +1309,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 34,
-                                                        "startColumn": 7
+                                                        "endLine": 34,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -1273,7 +1341,9 @@
                                 },
                                 "region": {
                                     "startLine": 45,
-                                    "startColumn": 2
+                                    "endLine": 45,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -1295,7 +1365,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 45,
-                                                        "startColumn": 2
+                                                        "endLine": 45,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -1325,7 +1397,9 @@
                                 },
                                 "region": {
                                     "startLine": 60,
-                                    "startColumn": 3
+                                    "endLine": 60,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -1347,7 +1421,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 60,
-                                                        "startColumn": 3
+                                                        "endLine": 60,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -1377,7 +1453,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1399,7 +1477,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1429,7 +1509,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1451,7 +1533,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1481,7 +1565,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1503,7 +1589,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1533,7 +1621,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1555,7 +1645,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1585,7 +1677,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1607,7 +1701,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1637,7 +1733,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1659,7 +1757,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1689,7 +1789,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1711,7 +1813,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1741,7 +1845,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1763,7 +1869,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1793,7 +1901,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1815,7 +1925,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1845,7 +1957,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1867,7 +1981,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1897,7 +2013,9 @@
                                 },
                                 "region": {
                                     "startLine": 4,
-                                    "startColumn": 7
+                                    "endLine": 4,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -1919,7 +2037,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4,
-                                                        "startColumn": 7
+                                                        "endLine": 4,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -1949,7 +2069,9 @@
                                 },
                                 "region": {
                                     "startLine": 5,
-                                    "startColumn": 7
+                                    "endLine": 5,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -1971,7 +2093,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 5,
-                                                        "startColumn": 7
+                                                        "endLine": 5,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -2001,7 +2125,9 @@
                                 },
                                 "region": {
                                     "startLine": 5,
-                                    "startColumn": 13
+                                    "endLine": 5,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -2023,7 +2149,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 5,
-                                                        "startColumn": 13
+                                                        "endLine": 5,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -2053,7 +2181,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 8
+                                    "endLine": 2,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -2075,7 +2205,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 8
+                                                        "endLine": 2,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -2105,7 +2237,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 23
+                                    "endLine": 2,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2127,7 +2261,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 23
+                                                        "endLine": 2,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2157,7 +2293,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 23
+                                    "endLine": 2,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2179,7 +2317,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 23
+                                                        "endLine": 2,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2209,7 +2349,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -2231,7 +2373,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -2261,7 +2405,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 23
+                                    "endLine": 3,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2283,7 +2429,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 23
+                                                        "endLine": 3,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2313,7 +2461,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 23
+                                    "endLine": 3,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2335,7 +2485,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 23
+                                                        "endLine": 3,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2365,7 +2517,9 @@
                                 },
                                 "region": {
                                     "startLine": 27,
-                                    "startColumn": 47
+                                    "endLine": 27,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -2387,7 +2541,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 27,
-                                                        "startColumn": 47
+                                                        "endLine": 27,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -2417,7 +2573,9 @@
                                 },
                                 "region": {
                                     "startLine": 28,
-                                    "startColumn": 32
+                                    "endLine": 28,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -2439,7 +2597,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 28,
-                                                        "startColumn": 32
+                                                        "endLine": 28,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -2469,7 +2629,9 @@
                                 },
                                 "region": {
                                     "startLine": 29,
-                                    "startColumn": 67
+                                    "endLine": 29,
+                                    "startColumn": 67,
+                                    "endColumn": 67
                                 }
                             }
                         }
@@ -2491,7 +2653,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 29,
-                                                        "startColumn": 67
+                                                        "endLine": 29,
+                                                        "startColumn": 67,
+                                                        "endColumn": 67
                                                     }
                                                 },
                                                 "message": {
@@ -2521,7 +2685,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 31
+                                    "endLine": 32,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -2543,7 +2709,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 31
+                                                        "endLine": 32,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -2573,7 +2741,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 49
+                                    "endLine": 32,
+                                    "startColumn": 49,
+                                    "endColumn": 49
                                 }
                             }
                         }
@@ -2595,7 +2765,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 49
+                                                        "endLine": 32,
+                                                        "startColumn": 49,
+                                                        "endColumn": 49
                                                     }
                                                 },
                                                 "message": {
@@ -2625,7 +2797,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -2647,7 +2821,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -2677,7 +2853,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -2699,7 +2877,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -2729,7 +2909,9 @@
                                 },
                                 "region": {
                                     "startLine": 54,
-                                    "startColumn": 9
+                                    "endLine": 54,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -2751,7 +2933,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 54,
-                                                        "startColumn": 9
+                                                        "endLine": 54,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -2781,7 +2965,9 @@
                                 },
                                 "region": {
                                     "startLine": 10,
-                                    "startColumn": 15
+                                    "endLine": 10,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -2803,7 +2989,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 10,
-                                                        "startColumn": 15
+                                                        "endLine": 10,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -2833,7 +3021,9 @@
                                 },
                                 "region": {
                                     "startLine": 10,
-                                    "startColumn": 27
+                                    "endLine": 10,
+                                    "startColumn": 27,
+                                    "endColumn": 27
                                 }
                             }
                         }
@@ -2855,7 +3045,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 10,
-                                                        "startColumn": 27
+                                                        "endLine": 10,
+                                                        "startColumn": 27,
+                                                        "endColumn": 27
                                                     }
                                                 },
                                                 "message": {
@@ -2885,7 +3077,9 @@
                                 },
                                 "region": {
                                     "startLine": 22,
-                                    "startColumn": 20
+                                    "endLine": 22,
+                                    "startColumn": 20,
+                                    "endColumn": 20
                                 }
                             }
                         }
@@ -2907,7 +3101,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 22,
-                                                        "startColumn": 20
+                                                        "endLine": 22,
+                                                        "startColumn": 20,
+                                                        "endColumn": 20
                                                     }
                                                 },
                                                 "message": {
@@ -2937,7 +3133,9 @@
                                 },
                                 "region": {
                                     "startLine": 23,
-                                    "startColumn": 64
+                                    "endLine": 23,
+                                    "startColumn": 64,
+                                    "endColumn": 64
                                 }
                             }
                         }
@@ -2959,7 +3157,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 23,
-                                                        "startColumn": 64
+                                                        "endLine": 23,
+                                                        "startColumn": 64,
+                                                        "endColumn": 64
                                                     }
                                                 },
                                                 "message": {
@@ -2989,7 +3189,9 @@
                                 },
                                 "region": {
                                     "startLine": 35,
-                                    "startColumn": 19
+                                    "endLine": 35,
+                                    "startColumn": 19,
+                                    "endColumn": 19
                                 }
                             }
                         }
@@ -3011,7 +3213,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 35,
-                                                        "startColumn": 19
+                                                        "endLine": 35,
+                                                        "startColumn": 19,
+                                                        "endColumn": 19
                                                     }
                                                 },
                                                 "message": {
@@ -3041,7 +3245,9 @@
                                 },
                                 "region": {
                                     "startLine": 43,
-                                    "startColumn": 66
+                                    "endLine": 43,
+                                    "startColumn": 66,
+                                    "endColumn": 66
                                 }
                             }
                         }
@@ -3063,7 +3269,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 43,
-                                                        "startColumn": 66
+                                                        "endLine": 43,
+                                                        "startColumn": 66,
+                                                        "endColumn": 66
                                                     }
                                                 },
                                                 "message": {
@@ -3093,7 +3301,9 @@
                                 },
                                 "region": {
                                     "startLine": 49,
-                                    "startColumn": 70
+                                    "endLine": 49,
+                                    "startColumn": 70,
+                                    "endColumn": 70
                                 }
                             }
                         }
@@ -3115,7 +3325,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 49,
-                                                        "startColumn": 70
+                                                        "endLine": 49,
+                                                        "startColumn": 70,
+                                                        "endColumn": 70
                                                     }
                                                 },
                                                 "message": {
@@ -3145,7 +3357,9 @@
                                 },
                                 "region": {
                                     "startLine": 52,
-                                    "startColumn": 25
+                                    "endLine": 52,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -3167,7 +3381,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 52,
-                                                        "startColumn": 25
+                                                        "endLine": 52,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -3197,7 +3413,9 @@
                                 },
                                 "region": {
                                     "startLine": 65,
-                                    "startColumn": 95
+                                    "endLine": 65,
+                                    "startColumn": 95,
+                                    "endColumn": 95
                                 }
                             }
                         }
@@ -3219,7 +3437,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 65,
-                                                        "startColumn": 95
+                                                        "endLine": 65,
+                                                        "startColumn": 95,
+                                                        "endColumn": 95
                                                     }
                                                 },
                                                 "message": {
@@ -3249,7 +3469,9 @@
                                 },
                                 "region": {
                                     "startLine": 66,
-                                    "startColumn": 87
+                                    "endLine": 66,
+                                    "startColumn": 87,
+                                    "endColumn": 87
                                 }
                             }
                         }
@@ -3271,7 +3493,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 66,
-                                                        "startColumn": 87
+                                                        "endLine": 66,
+                                                        "startColumn": 87,
+                                                        "endColumn": 87
                                                     }
                                                 },
                                                 "message": {
@@ -3301,7 +3525,9 @@
                                 },
                                 "region": {
                                     "startLine": 67,
-                                    "startColumn": 69
+                                    "endLine": 67,
+                                    "startColumn": 69,
+                                    "endColumn": 69
                                 }
                             }
                         }
@@ -3323,7 +3549,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 67,
-                                                        "startColumn": 69
+                                                        "endLine": 67,
+                                                        "startColumn": 69,
+                                                        "endColumn": 69
                                                     }
                                                 },
                                                 "message": {
@@ -3353,7 +3581,9 @@
                                 },
                                 "region": {
                                     "startLine": 68,
-                                    "startColumn": 27
+                                    "endLine": 68,
+                                    "startColumn": 27,
+                                    "endColumn": 27
                                 }
                             }
                         }
@@ -3375,7 +3605,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 68,
-                                                        "startColumn": 27
+                                                        "endLine": 68,
+                                                        "startColumn": 27,
+                                                        "endColumn": 27
                                                     }
                                                 },
                                                 "message": {
@@ -3405,7 +3637,9 @@
                                 },
                                 "region": {
                                     "startLine": 69,
-                                    "startColumn": 33
+                                    "endLine": 69,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3427,7 +3661,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 69,
-                                                        "startColumn": 33
+                                                        "endLine": 69,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3457,7 +3693,9 @@
                                 },
                                 "region": {
                                     "startLine": 70,
-                                    "startColumn": 25
+                                    "endLine": 70,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -3479,7 +3717,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 70,
-                                                        "startColumn": 25
+                                                        "endLine": 70,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -3509,7 +3749,9 @@
                                 },
                                 "region": {
                                     "startLine": 72,
-                                    "startColumn": 33
+                                    "endLine": 72,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3531,7 +3773,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 72,
-                                                        "startColumn": 33
+                                                        "endLine": 72,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3561,7 +3805,9 @@
                                 },
                                 "region": {
                                     "startLine": 74,
-                                    "startColumn": 33
+                                    "endLine": 74,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3583,7 +3829,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 74,
-                                                        "startColumn": 33
+                                                        "endLine": 74,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3613,7 +3861,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 33
+                                    "endLine": 75,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3635,7 +3885,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 33
+                                                        "endLine": 75,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3665,7 +3917,9 @@
                                 },
                                 "region": {
                                     "startLine": 76,
-                                    "startColumn": 33
+                                    "endLine": 76,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3687,7 +3941,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 76,
-                                                        "startColumn": 33
+                                                        "endLine": 76,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3717,7 +3973,9 @@
                                 },
                                 "region": {
                                     "startLine": 79,
-                                    "startColumn": 87
+                                    "endLine": 79,
+                                    "startColumn": 87,
+                                    "endColumn": 87
                                 }
                             }
                         }
@@ -3739,7 +3997,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 79,
-                                                        "startColumn": 87
+                                                        "endLine": 79,
+                                                        "startColumn": 87,
+                                                        "endColumn": 87
                                                     }
                                                 },
                                                 "message": {
@@ -3769,7 +4029,9 @@
                                 },
                                 "region": {
                                     "startLine": 81,
-                                    "startColumn": 89
+                                    "endLine": 81,
+                                    "startColumn": 89,
+                                    "endColumn": 89
                                 }
                             }
                         }
@@ -3791,7 +4053,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 81,
-                                                        "startColumn": 89
+                                                        "endLine": 81,
+                                                        "startColumn": 89,
+                                                        "endColumn": 89
                                                     }
                                                 },
                                                 "message": {
@@ -3821,7 +4085,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 86
+                                    "endLine": 83,
+                                    "startColumn": 86,
+                                    "endColumn": 86
                                 }
                             }
                         }
@@ -3843,7 +4109,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 86
+                                                        "endLine": 83,
+                                                        "startColumn": 86,
+                                                        "endColumn": 86
                                                     }
                                                 },
                                                 "message": {
@@ -3873,7 +4141,9 @@
                                 },
                                 "region": {
                                     "startLine": 85,
-                                    "startColumn": 98
+                                    "endLine": 85,
+                                    "startColumn": 98,
+                                    "endColumn": 98
                                 }
                             }
                         }
@@ -3895,7 +4165,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 85,
-                                                        "startColumn": 98
+                                                        "endLine": 85,
+                                                        "startColumn": 98,
+                                                        "endColumn": 98
                                                     }
                                                 },
                                                 "message": {
@@ -3925,7 +4197,9 @@
                                 },
                                 "region": {
                                     "startLine": 87,
-                                    "startColumn": 88
+                                    "endLine": 87,
+                                    "startColumn": 88,
+                                    "endColumn": 88
                                 }
                             }
                         }
@@ -3947,7 +4221,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 87,
-                                                        "startColumn": 88
+                                                        "endLine": 87,
+                                                        "startColumn": 88,
+                                                        "endColumn": 88
                                                     }
                                                 },
                                                 "message": {
@@ -3977,7 +4253,9 @@
                                 },
                                 "region": {
                                     "startLine": 89,
-                                    "startColumn": 33
+                                    "endLine": 89,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3999,7 +4277,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 89,
-                                                        "startColumn": 33
+                                                        "endLine": 89,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4029,7 +4309,9 @@
                                 },
                                 "region": {
                                     "startLine": 90,
-                                    "startColumn": 33
+                                    "endLine": 90,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4051,7 +4333,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 90,
-                                                        "startColumn": 33
+                                                        "endLine": 90,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4081,7 +4365,9 @@
                                 },
                                 "region": {
                                     "startLine": 94,
-                                    "startColumn": 33
+                                    "endLine": 94,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4103,7 +4389,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 94,
-                                                        "startColumn": 33
+                                                        "endLine": 94,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4133,7 +4421,9 @@
                                 },
                                 "region": {
                                     "startLine": 96,
-                                    "startColumn": 33
+                                    "endLine": 96,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4155,7 +4445,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 96,
-                                                        "startColumn": 33
+                                                        "endLine": 96,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4185,7 +4477,9 @@
                                 },
                                 "region": {
                                     "startLine": 99,
-                                    "startColumn": 17
+                                    "endLine": 99,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -4207,7 +4501,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 99,
-                                                        "startColumn": 17
+                                                        "endLine": 99,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -4237,7 +4533,9 @@
                                 },
                                 "region": {
                                     "startLine": 105,
-                                    "startColumn": 21
+                                    "endLine": 105,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -4259,7 +4557,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 105,
-                                                        "startColumn": 21
+                                                        "endLine": 105,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -4289,7 +4589,9 @@
                                 },
                                 "region": {
                                     "startLine": 106,
-                                    "startColumn": 21
+                                    "endLine": 106,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -4311,7 +4613,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 106,
-                                                        "startColumn": 21
+                                                        "endLine": 106,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -4341,7 +4645,9 @@
                                 },
                                 "region": {
                                     "startLine": 108,
-                                    "startColumn": 33
+                                    "endLine": 108,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4363,7 +4669,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 108,
-                                                        "startColumn": 33
+                                                        "endLine": 108,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4393,7 +4701,9 @@
                                 },
                                 "region": {
                                     "startLine": 109,
-                                    "startColumn": 33
+                                    "endLine": 109,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4415,7 +4725,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 109,
-                                                        "startColumn": 33
+                                                        "endLine": 109,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4445,7 +4757,9 @@
                                 },
                                 "region": {
                                     "startLine": 116,
-                                    "startColumn": 4
+                                    "endLine": 116,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -4467,7 +4781,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 116,
-                                                        "startColumn": 4
+                                                        "endLine": 116,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -4497,7 +4813,9 @@
                                 },
                                 "region": {
                                     "startLine": 118,
-                                    "startColumn": 34
+                                    "endLine": 118,
+                                    "startColumn": 34,
+                                    "endColumn": 34
                                 }
                             }
                         }
@@ -4519,7 +4837,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 118,
-                                                        "startColumn": 34
+                                                        "endLine": 118,
+                                                        "startColumn": 34,
+                                                        "endColumn": 34
                                                     }
                                                 },
                                                 "message": {
@@ -4549,7 +4869,9 @@
                                 },
                                 "region": {
                                     "startLine": 118,
-                                    "startColumn": 39
+                                    "endLine": 118,
+                                    "startColumn": 39,
+                                    "endColumn": 39
                                 }
                             }
                         }
@@ -4571,7 +4893,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 118,
-                                                        "startColumn": 39
+                                                        "endLine": 118,
+                                                        "startColumn": 39,
+                                                        "endColumn": 39
                                                     }
                                                 },
                                                 "message": {
@@ -4601,7 +4925,9 @@
                                 },
                                 "region": {
                                     "startLine": 124,
-                                    "startColumn": 99
+                                    "endLine": 124,
+                                    "startColumn": 99,
+                                    "endColumn": 99
                                 }
                             }
                         }
@@ -4623,7 +4949,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 124,
-                                                        "startColumn": 99
+                                                        "endLine": 124,
+                                                        "startColumn": 99,
+                                                        "endColumn": 99
                                                     }
                                                 },
                                                 "message": {
@@ -4653,7 +4981,9 @@
                                 },
                                 "region": {
                                     "startLine": 125,
-                                    "startColumn": 91
+                                    "endLine": 125,
+                                    "startColumn": 91,
+                                    "endColumn": 91
                                 }
                             }
                         }
@@ -4675,7 +5005,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 125,
-                                                        "startColumn": 91
+                                                        "endLine": 125,
+                                                        "startColumn": 91,
+                                                        "endColumn": 91
                                                     }
                                                 },
                                                 "message": {
@@ -4705,7 +5037,9 @@
                                 },
                                 "region": {
                                     "startLine": 126,
-                                    "startColumn": 73
+                                    "endLine": 126,
+                                    "startColumn": 73,
+                                    "endColumn": 73
                                 }
                             }
                         }
@@ -4727,7 +5061,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 126,
-                                                        "startColumn": 73
+                                                        "endLine": 126,
+                                                        "startColumn": 73,
+                                                        "endColumn": 73
                                                     }
                                                 },
                                                 "message": {
@@ -4757,7 +5093,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 31
+                                    "endLine": 127,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -4779,7 +5117,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 31
+                                                        "endLine": 127,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -4809,7 +5149,9 @@
                                 },
                                 "region": {
                                     "startLine": 128,
-                                    "startColumn": 37
+                                    "endLine": 128,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -4831,7 +5173,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 128,
-                                                        "startColumn": 37
+                                                        "endLine": 128,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -4861,7 +5205,9 @@
                                 },
                                 "region": {
                                     "startLine": 129,
-                                    "startColumn": 29
+                                    "endLine": 129,
+                                    "startColumn": 29,
+                                    "endColumn": 29
                                 }
                             }
                         }
@@ -4883,7 +5229,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 129,
-                                                        "startColumn": 29
+                                                        "endLine": 129,
+                                                        "startColumn": 29,
+                                                        "endColumn": 29
                                                     }
                                                 },
                                                 "message": {
@@ -4913,7 +5261,9 @@
                                 },
                                 "region": {
                                     "startLine": 131,
-                                    "startColumn": 37
+                                    "endLine": 131,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -4935,7 +5285,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 131,
-                                                        "startColumn": 37
+                                                        "endLine": 131,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -4965,7 +5317,9 @@
                                 },
                                 "region": {
                                     "startLine": 133,
-                                    "startColumn": 37
+                                    "endLine": 133,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -4987,7 +5341,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 133,
-                                                        "startColumn": 37
+                                                        "endLine": 133,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5017,7 +5373,9 @@
                                 },
                                 "region": {
                                     "startLine": 134,
-                                    "startColumn": 37
+                                    "endLine": 134,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5039,7 +5397,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 134,
-                                                        "startColumn": 37
+                                                        "endLine": 134,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5069,7 +5429,9 @@
                                 },
                                 "region": {
                                     "startLine": 135,
-                                    "startColumn": 37
+                                    "endLine": 135,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5091,7 +5453,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 135,
-                                                        "startColumn": 37
+                                                        "endLine": 135,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5121,7 +5485,9 @@
                                 },
                                 "region": {
                                     "startLine": 138,
-                                    "startColumn": 91
+                                    "endLine": 138,
+                                    "startColumn": 91,
+                                    "endColumn": 91
                                 }
                             }
                         }
@@ -5143,7 +5509,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 138,
-                                                        "startColumn": 91
+                                                        "endLine": 138,
+                                                        "startColumn": 91,
+                                                        "endColumn": 91
                                                     }
                                                 },
                                                 "message": {
@@ -5173,7 +5541,9 @@
                                 },
                                 "region": {
                                     "startLine": 140,
-                                    "startColumn": 93
+                                    "endLine": 140,
+                                    "startColumn": 93,
+                                    "endColumn": 93
                                 }
                             }
                         }
@@ -5195,7 +5565,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 140,
-                                                        "startColumn": 93
+                                                        "endLine": 140,
+                                                        "startColumn": 93,
+                                                        "endColumn": 93
                                                     }
                                                 },
                                                 "message": {
@@ -5225,7 +5597,9 @@
                                 },
                                 "region": {
                                     "startLine": 142,
-                                    "startColumn": 90
+                                    "endLine": 142,
+                                    "startColumn": 90,
+                                    "endColumn": 90
                                 }
                             }
                         }
@@ -5247,7 +5621,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 142,
-                                                        "startColumn": 90
+                                                        "endLine": 142,
+                                                        "startColumn": 90,
+                                                        "endColumn": 90
                                                     }
                                                 },
                                                 "message": {
@@ -5277,7 +5653,9 @@
                                 },
                                 "region": {
                                     "startLine": 144,
-                                    "startColumn": 102
+                                    "endLine": 144,
+                                    "startColumn": 102,
+                                    "endColumn": 102
                                 }
                             }
                         }
@@ -5299,7 +5677,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 144,
-                                                        "startColumn": 102
+                                                        "endLine": 144,
+                                                        "startColumn": 102,
+                                                        "endColumn": 102
                                                     }
                                                 },
                                                 "message": {
@@ -5329,7 +5709,9 @@
                                 },
                                 "region": {
                                     "startLine": 146,
-                                    "startColumn": 92
+                                    "endLine": 146,
+                                    "startColumn": 92,
+                                    "endColumn": 92
                                 }
                             }
                         }
@@ -5351,7 +5733,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 146,
-                                                        "startColumn": 92
+                                                        "endLine": 146,
+                                                        "startColumn": 92,
+                                                        "endColumn": 92
                                                     }
                                                 },
                                                 "message": {
@@ -5381,7 +5765,9 @@
                                 },
                                 "region": {
                                     "startLine": 148,
-                                    "startColumn": 37
+                                    "endLine": 148,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5403,7 +5789,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 148,
-                                                        "startColumn": 37
+                                                        "endLine": 148,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5433,7 +5821,9 @@
                                 },
                                 "region": {
                                     "startLine": 149,
-                                    "startColumn": 37
+                                    "endLine": 149,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5455,7 +5845,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 149,
-                                                        "startColumn": 37
+                                                        "endLine": 149,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5485,7 +5877,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 37
+                                    "endLine": 153,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5507,7 +5901,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 37
+                                                        "endLine": 153,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5537,7 +5933,9 @@
                                 },
                                 "region": {
                                     "startLine": 155,
-                                    "startColumn": 37
+                                    "endLine": 155,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5559,7 +5957,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 155,
-                                                        "startColumn": 37
+                                                        "endLine": 155,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5589,7 +5989,9 @@
                                 },
                                 "region": {
                                     "startLine": 158,
-                                    "startColumn": 21
+                                    "endLine": 158,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -5611,7 +6013,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 158,
-                                                        "startColumn": 21
+                                                        "endLine": 158,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -5641,7 +6045,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 25
+                                    "endLine": 164,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -5663,7 +6069,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 25
+                                                        "endLine": 164,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -5693,7 +6101,9 @@
                                 },
                                 "region": {
                                     "startLine": 165,
-                                    "startColumn": 25
+                                    "endLine": 165,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -5715,7 +6125,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 165,
-                                                        "startColumn": 25
+                                                        "endLine": 165,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -5745,7 +6157,9 @@
                                 },
                                 "region": {
                                     "startLine": 167,
-                                    "startColumn": 37
+                                    "endLine": 167,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5767,7 +6181,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 167,
-                                                        "startColumn": 37
+                                                        "endLine": 167,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5797,7 +6213,9 @@
                                 },
                                 "region": {
                                     "startLine": 172,
-                                    "startColumn": 55
+                                    "endLine": 172,
+                                    "startColumn": 55,
+                                    "endColumn": 55
                                 }
                             }
                         }
@@ -5819,7 +6237,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 172,
-                                                        "startColumn": 55
+                                                        "endLine": 172,
+                                                        "startColumn": 55,
+                                                        "endColumn": 55
                                                     }
                                                 },
                                                 "message": {
@@ -5849,7 +6269,9 @@
                                 },
                                 "region": {
                                     "startLine": 173,
-                                    "startColumn": 100
+                                    "endLine": 173,
+                                    "startColumn": 100,
+                                    "endColumn": 100
                                 }
                             }
                         }
@@ -5871,7 +6293,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 173,
-                                                        "startColumn": 100
+                                                        "endLine": 173,
+                                                        "startColumn": 100,
+                                                        "endColumn": 100
                                                     }
                                                 },
                                                 "message": {
@@ -5901,7 +6325,9 @@
                                 },
                                 "region": {
                                     "startLine": 174,
-                                    "startColumn": 55
+                                    "endLine": 174,
+                                    "startColumn": 55,
+                                    "endColumn": 55
                                 }
                             }
                         }
@@ -5923,7 +6349,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 174,
-                                                        "startColumn": 55
+                                                        "endLine": 174,
+                                                        "startColumn": 55,
+                                                        "endColumn": 55
                                                     }
                                                 },
                                                 "message": {
@@ -5953,7 +6381,9 @@
                                 },
                                 "region": {
                                     "startLine": 179,
-                                    "startColumn": 55
+                                    "endLine": 179,
+                                    "startColumn": 55,
+                                    "endColumn": 55
                                 }
                             }
                         }
@@ -5975,7 +6405,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 179,
-                                                        "startColumn": 55
+                                                        "endLine": 179,
+                                                        "startColumn": 55,
+                                                        "endColumn": 55
                                                     }
                                                 },
                                                 "message": {
@@ -6005,7 +6437,9 @@
                                 },
                                 "region": {
                                     "startLine": 27,
-                                    "startColumn": 47
+                                    "endLine": 27,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -6027,7 +6461,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 27,
-                                                        "startColumn": 47
+                                                        "endLine": 27,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -6057,7 +6493,9 @@
                                 },
                                 "region": {
                                     "startLine": 28,
-                                    "startColumn": 32
+                                    "endLine": 28,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -6079,7 +6517,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 28,
-                                                        "startColumn": 32
+                                                        "endLine": 28,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -6109,7 +6549,9 @@
                                 },
                                 "region": {
                                     "startLine": 29,
-                                    "startColumn": 67
+                                    "endLine": 29,
+                                    "startColumn": 67,
+                                    "endColumn": 67
                                 }
                             }
                         }
@@ -6131,7 +6573,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 29,
-                                                        "startColumn": 67
+                                                        "endLine": 29,
+                                                        "startColumn": 67,
+                                                        "endColumn": 67
                                                     }
                                                 },
                                                 "message": {
@@ -6161,7 +6605,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 31
+                                    "endLine": 32,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -6183,7 +6629,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 31
+                                                        "endLine": 32,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -6213,7 +6661,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 49
+                                    "endLine": 32,
+                                    "startColumn": 49,
+                                    "endColumn": 49
                                 }
                             }
                         }
@@ -6235,7 +6685,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 49
+                                                        "endLine": 32,
+                                                        "startColumn": 49,
+                                                        "endColumn": 49
                                                     }
                                                 },
                                                 "message": {
@@ -6265,7 +6717,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -6287,7 +6741,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -6317,7 +6773,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -6339,7 +6797,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -6369,7 +6829,9 @@
                                 },
                                 "region": {
                                     "startLine": 54,
-                                    "startColumn": 9
+                                    "endLine": 54,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -6391,7 +6853,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 54,
-                                                        "startColumn": 9
+                                                        "endLine": 54,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -6421,7 +6885,9 @@
                                 },
                                 "region": {
                                     "startLine": 10,
-                                    "startColumn": 23
+                                    "endLine": 10,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -6443,7 +6909,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 10,
-                                                        "startColumn": 23
+                                                        "endLine": 10,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -6473,7 +6941,9 @@
                                 },
                                 "region": {
                                     "startLine": 14,
-                                    "startColumn": 6
+                                    "endLine": 14,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6495,7 +6965,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 14,
-                                                        "startColumn": 6
+                                                        "endLine": 14,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6525,7 +6997,9 @@
                                 },
                                 "region": {
                                     "startLine": 16,
-                                    "startColumn": 6
+                                    "endLine": 16,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6547,7 +7021,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 16,
-                                                        "startColumn": 6
+                                                        "endLine": 16,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6577,7 +7053,9 @@
                                 },
                                 "region": {
                                     "startLine": 27,
-                                    "startColumn": 47
+                                    "endLine": 27,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -6599,7 +7077,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 27,
-                                                        "startColumn": 47
+                                                        "endLine": 27,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -6629,7 +7109,9 @@
                                 },
                                 "region": {
                                     "startLine": 28,
-                                    "startColumn": 32
+                                    "endLine": 28,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -6651,7 +7133,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 28,
-                                                        "startColumn": 32
+                                                        "endLine": 28,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -6681,7 +7165,9 @@
                                 },
                                 "region": {
                                     "startLine": 29,
-                                    "startColumn": 67
+                                    "endLine": 29,
+                                    "startColumn": 67,
+                                    "endColumn": 67
                                 }
                             }
                         }
@@ -6703,7 +7189,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 29,
-                                                        "startColumn": 67
+                                                        "endLine": 29,
+                                                        "startColumn": 67,
+                                                        "endColumn": 67
                                                     }
                                                 },
                                                 "message": {
@@ -6733,7 +7221,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 31
+                                    "endLine": 32,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -6755,7 +7245,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 31
+                                                        "endLine": 32,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -6785,7 +7277,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 49
+                                    "endLine": 32,
+                                    "startColumn": 49,
+                                    "endColumn": 49
                                 }
                             }
                         }
@@ -6807,7 +7301,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 49
+                                                        "endLine": 32,
+                                                        "startColumn": 49,
+                                                        "endColumn": 49
                                                     }
                                                 },
                                                 "message": {
@@ -6837,7 +7333,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 11
+                                    "endLine": 41,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -6859,7 +7357,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 11
+                                                        "endLine": 41,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -6889,7 +7389,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 11
+                                    "endLine": 41,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -6911,7 +7413,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 11
+                                                        "endLine": 41,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -6941,7 +7445,9 @@
                                 },
                                 "region": {
                                     "startLine": 59,
-                                    "startColumn": 14
+                                    "endLine": 59,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -6963,7 +7469,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 59,
-                                                        "startColumn": 14
+                                                        "endLine": 59,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -6993,7 +7501,9 @@
                                 },
                                 "region": {
                                     "startLine": 60,
-                                    "startColumn": 14
+                                    "endLine": 60,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -7015,7 +7525,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 60,
-                                                        "startColumn": 14
+                                                        "endLine": 60,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -7045,7 +7557,9 @@
                                 },
                                 "region": {
                                     "startLine": 61,
-                                    "startColumn": 20
+                                    "endLine": 61,
+                                    "startColumn": 20,
+                                    "endColumn": 20
                                 }
                             }
                         }
@@ -7067,7 +7581,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 61,
-                                                        "startColumn": 20
+                                                        "endLine": 61,
+                                                        "startColumn": 20,
+                                                        "endColumn": 20
                                                     }
                                                 },
                                                 "message": {
@@ -7097,7 +7613,9 @@
                                 },
                                 "region": {
                                     "startLine": 62,
-                                    "startColumn": 17
+                                    "endLine": 62,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -7119,7 +7637,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 62,
-                                                        "startColumn": 17
+                                                        "endLine": 62,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -7149,7 +7669,9 @@
                                 },
                                 "region": {
                                     "startLine": 71,
-                                    "startColumn": 9
+                                    "endLine": 71,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7171,7 +7693,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 71,
-                                                        "startColumn": 9
+                                                        "endLine": 71,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7201,7 +7725,9 @@
                                 },
                                 "region": {
                                     "startLine": 22,
-                                    "startColumn": 9
+                                    "endLine": 22,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7223,7 +7749,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 22,
-                                                        "startColumn": 9
+                                                        "endLine": 22,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7253,7 +7781,9 @@
                                 },
                                 "region": {
                                     "startLine": 34,
-                                    "startColumn": 9
+                                    "endLine": 34,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7275,7 +7805,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 34,
-                                                        "startColumn": 9
+                                                        "endLine": 34,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7305,7 +7837,9 @@
                                 },
                                 "region": {
                                     "startLine": 39,
-                                    "startColumn": 9
+                                    "endLine": 39,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7327,7 +7861,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 39,
-                                                        "startColumn": 9
+                                                        "endLine": 39,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7357,7 +7893,9 @@
                                 },
                                 "region": {
                                     "startLine": 61,
-                                    "startColumn": 1
+                                    "endLine": 61,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -7379,7 +7917,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 61,
-                                                        "startColumn": 1
+                                                        "endLine": 61,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -7409,7 +7949,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 6
+                                    "endLine": 63,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -7431,7 +7973,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 6
+                                                        "endLine": 63,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -7461,7 +8005,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 7
+                                    "endLine": 63,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -7483,7 +8029,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 7
+                                                        "endLine": 63,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -7513,7 +8061,9 @@
                                 },
                                 "region": {
                                     "startLine": 73,
-                                    "startColumn": 5
+                                    "endLine": 73,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -7535,7 +8085,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 73,
-                                                        "startColumn": 5
+                                                        "endLine": 73,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -7565,7 +8117,9 @@
                                 },
                                 "region": {
                                     "startLine": 73,
-                                    "startColumn": 8
+                                    "endLine": 73,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -7587,7 +8141,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 73,
-                                                        "startColumn": 8
+                                                        "endLine": 73,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -7617,7 +8173,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 2
+                                    "endLine": 84,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7639,7 +8197,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 2
+                                                        "endLine": 84,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7669,7 +8229,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 7
+                                    "endLine": 84,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -7691,7 +8253,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 7
+                                                        "endLine": 84,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -7721,7 +8285,9 @@
                                 },
                                 "region": {
                                     "startLine": 89,
-                                    "startColumn": 31
+                                    "endLine": 89,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -7743,7 +8309,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 89,
-                                                        "startColumn": 31
+                                                        "endLine": 89,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -7773,7 +8341,9 @@
                                 },
                                 "region": {
                                     "startLine": 94,
-                                    "startColumn": 10
+                                    "endLine": 94,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -7795,7 +8365,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 94,
-                                                        "startColumn": 10
+                                                        "endLine": 94,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -7825,7 +8397,9 @@
                                 },
                                 "region": {
                                     "startLine": 100,
-                                    "startColumn": 15
+                                    "endLine": 100,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -7847,7 +8421,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 100,
-                                                        "startColumn": 15
+                                                        "endLine": 100,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -7877,7 +8453,9 @@
                                 },
                                 "region": {
                                     "startLine": 100,
-                                    "startColumn": 23
+                                    "endLine": 100,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -7899,7 +8477,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 100,
-                                                        "startColumn": 23
+                                                        "endLine": 100,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -7929,7 +8509,9 @@
                                 },
                                 "region": {
                                     "startLine": 100,
-                                    "startColumn": 29
+                                    "endLine": 100,
+                                    "startColumn": 29,
+                                    "endColumn": 29
                                 }
                             }
                         }
@@ -7951,7 +8533,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 100,
-                                                        "startColumn": 29
+                                                        "endLine": 100,
+                                                        "startColumn": 29,
+                                                        "endColumn": 29
                                                     }
                                                 },
                                                 "message": {
@@ -7981,7 +8565,9 @@
                                 },
                                 "region": {
                                     "startLine": 102,
-                                    "startColumn": 9
+                                    "endLine": 102,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -8003,7 +8589,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 102,
-                                                        "startColumn": 9
+                                                        "endLine": 102,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -8033,7 +8621,9 @@
                                 },
                                 "region": {
                                     "startLine": 102,
-                                    "startColumn": 10
+                                    "endLine": 102,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -8055,7 +8645,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 102,
-                                                        "startColumn": 10
+                                                        "endLine": 102,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -8085,7 +8677,9 @@
                                 },
                                 "region": {
                                     "startLine": 107,
-                                    "startColumn": 10
+                                    "endLine": 107,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -8107,7 +8701,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 107,
-                                                        "startColumn": 10
+                                                        "endLine": 107,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -8137,7 +8733,9 @@
                                 },
                                 "region": {
                                     "startLine": 107,
-                                    "startColumn": 11
+                                    "endLine": 107,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -8159,7 +8757,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 107,
-                                                        "startColumn": 11
+                                                        "endLine": 107,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -8189,7 +8789,9 @@
                                 },
                                 "region": {
                                     "startLine": 109,
-                                    "startColumn": 15
+                                    "endLine": 109,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -8211,7 +8813,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 109,
-                                                        "startColumn": 15
+                                                        "endLine": 109,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -8241,7 +8845,9 @@
                                 },
                                 "region": {
                                     "startLine": 110,
-                                    "startColumn": 17
+                                    "endLine": 110,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -8263,7 +8869,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 110,
-                                                        "startColumn": 17
+                                                        "endLine": 110,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -8293,7 +8901,9 @@
                                 },
                                 "region": {
                                     "startLine": 118,
-                                    "startColumn": 31
+                                    "endLine": 118,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -8315,7 +8925,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 118,
-                                                        "startColumn": 31
+                                                        "endLine": 118,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -8345,7 +8957,9 @@
                                 },
                                 "region": {
                                     "startLine": 120,
-                                    "startColumn": 18
+                                    "endLine": 120,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8367,7 +8981,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 120,
-                                                        "startColumn": 18
+                                                        "endLine": 120,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8397,7 +9013,9 @@
                                 },
                                 "region": {
                                     "startLine": 124,
-                                    "startColumn": 18
+                                    "endLine": 124,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8419,7 +9037,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 124,
-                                                        "startColumn": 18
+                                                        "endLine": 124,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8449,7 +9069,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 12
+                                    "endLine": 127,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -8471,7 +9093,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 12
+                                                        "endLine": 127,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -8501,7 +9125,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 13
+                                    "endLine": 127,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -8523,7 +9149,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 13
+                                                        "endLine": 127,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -8553,7 +9181,9 @@
                                 },
                                 "region": {
                                     "startLine": 129,
-                                    "startColumn": 15
+                                    "endLine": 129,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -8575,7 +9205,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 129,
-                                                        "startColumn": 15
+                                                        "endLine": 129,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -8605,7 +9237,9 @@
                                 },
                                 "region": {
                                     "startLine": 130,
-                                    "startColumn": 17
+                                    "endLine": 130,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -8627,7 +9261,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 130,
-                                                        "startColumn": 17
+                                                        "endLine": 130,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -8657,7 +9293,9 @@
                                 },
                                 "region": {
                                     "startLine": 137,
-                                    "startColumn": 31
+                                    "endLine": 137,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -8679,7 +9317,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 137,
-                                                        "startColumn": 31
+                                                        "endLine": 137,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -8709,7 +9349,9 @@
                                 },
                                 "region": {
                                     "startLine": 139,
-                                    "startColumn": 18
+                                    "endLine": 139,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8731,7 +9373,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 139,
-                                                        "startColumn": 18
+                                                        "endLine": 139,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8761,7 +9405,9 @@
                                 },
                                 "region": {
                                     "startLine": 143,
-                                    "startColumn": 18
+                                    "endLine": 143,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8783,7 +9429,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 143,
-                                                        "startColumn": 18
+                                                        "endLine": 143,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8813,7 +9461,9 @@
                                 },
                                 "region": {
                                     "startLine": 147,
-                                    "startColumn": 19
+                                    "endLine": 147,
+                                    "startColumn": 19,
+                                    "endColumn": 19
                                 }
                             }
                         }
@@ -8835,7 +9485,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 147,
-                                                        "startColumn": 19
+                                                        "endLine": 147,
+                                                        "startColumn": 19,
+                                                        "endColumn": 19
                                                     }
                                                 },
                                                 "message": {
@@ -8865,7 +9517,9 @@
                                 },
                                 "region": {
                                     "startLine": 147,
-                                    "startColumn": 28
+                                    "endLine": 147,
+                                    "startColumn": 28,
+                                    "endColumn": 28
                                 }
                             }
                         }
@@ -8887,7 +9541,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 147,
-                                                        "startColumn": 28
+                                                        "endLine": 147,
+                                                        "startColumn": 28,
+                                                        "endColumn": 28
                                                     }
                                                 },
                                                 "message": {
@@ -8917,7 +9573,9 @@
                                 },
                                 "region": {
                                     "startLine": 147,
-                                    "startColumn": 47
+                                    "endLine": 147,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -8939,7 +9597,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 147,
-                                                        "startColumn": 47
+                                                        "endLine": 147,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -8969,7 +9629,9 @@
                                 },
                                 "region": {
                                     "startLine": 148,
-                                    "startColumn": 11
+                                    "endLine": 148,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -8991,7 +9653,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 148,
-                                                        "startColumn": 11
+                                                        "endLine": 148,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -9021,7 +9685,9 @@
                                 },
                                 "region": {
                                     "startLine": 148,
-                                    "startColumn": 12
+                                    "endLine": 148,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -9043,7 +9709,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 148,
-                                                        "startColumn": 12
+                                                        "endLine": 148,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -9073,7 +9741,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 10
+                                    "endLine": 153,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -9095,7 +9765,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 10
+                                                        "endLine": 153,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -9125,7 +9797,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 11
+                                    "endLine": 153,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -9147,7 +9821,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 11
+                                                        "endLine": 153,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -9177,7 +9853,9 @@
                                 },
                                 "region": {
                                     "startLine": 155,
-                                    "startColumn": 17
+                                    "endLine": 155,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -9199,7 +9877,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 155,
-                                                        "startColumn": 17
+                                                        "endLine": 155,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -9229,7 +9909,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 12
+                                    "endLine": 164,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -9251,7 +9933,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 12
+                                                        "endLine": 164,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -9281,7 +9965,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 13
+                                    "endLine": 164,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -9303,7 +9989,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 13
+                                                        "endLine": 164,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -9333,7 +10021,9 @@
                                 },
                                 "region": {
                                     "startLine": 166,
-                                    "startColumn": 17
+                                    "endLine": 166,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -9355,7 +10045,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 166,
-                                                        "startColumn": 17
+                                                        "endLine": 166,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -9385,7 +10077,9 @@
                                 },
                                 "region": {
                                     "startLine": 175,
-                                    "startColumn": 19
+                                    "endLine": 175,
+                                    "startColumn": 19,
+                                    "endColumn": 19
                                 }
                             }
                         }
@@ -9407,7 +10101,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 175,
-                                                        "startColumn": 19
+                                                        "endLine": 175,
+                                                        "startColumn": 19,
+                                                        "endColumn": 19
                                                     }
                                                 },
                                                 "message": {
@@ -9437,7 +10133,9 @@
                                 },
                                 "region": {
                                     "startLine": 175,
-                                    "startColumn": 28
+                                    "endLine": 175,
+                                    "startColumn": 28,
+                                    "endColumn": 28
                                 }
                             }
                         }
@@ -9459,7 +10157,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 175,
-                                                        "startColumn": 28
+                                                        "endLine": 175,
+                                                        "startColumn": 28,
+                                                        "endColumn": 28
                                                     }
                                                 },
                                                 "message": {
@@ -9489,7 +10189,9 @@
                                 },
                                 "region": {
                                     "startLine": 175,
-                                    "startColumn": 47
+                                    "endLine": 175,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -9511,7 +10213,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 175,
-                                                        "startColumn": 47
+                                                        "endLine": 175,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -9541,7 +10245,9 @@
                                 },
                                 "region": {
                                     "startLine": 184,
-                                    "startColumn": 11
+                                    "endLine": 184,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -9563,7 +10269,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 184,
-                                                        "startColumn": 11
+                                                        "endLine": 184,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -9593,7 +10301,9 @@
                                 },
                                 "region": {
                                     "startLine": 184,
-                                    "startColumn": 14
+                                    "endLine": 184,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -9615,7 +10325,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 184,
-                                                        "startColumn": 14
+                                                        "endLine": 184,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -9645,7 +10357,9 @@
                                 },
                                 "region": {
                                     "startLine": 190,
-                                    "startColumn": 1
+                                    "endLine": 190,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -9667,7 +10381,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 190,
-                                                        "startColumn": 1
+                                                        "endLine": 190,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -9697,7 +10413,9 @@
                                 },
                                 "region": {
                                     "startLine": 190,
-                                    "startColumn": 4
+                                    "endLine": 190,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -9719,7 +10437,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 190,
-                                                        "startColumn": 4
+                                                        "endLine": 190,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -9749,7 +10469,9 @@
                                 },
                                 "region": {
                                     "startLine": 199,
-                                    "startColumn": 7
+                                    "endLine": 199,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -9771,7 +10493,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 199,
-                                                        "startColumn": 7
+                                                        "endLine": 199,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -9801,7 +10525,9 @@
                                 },
                                 "region": {
                                     "startLine": 199,
-                                    "startColumn": 7
+                                    "endLine": 199,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -9823,7 +10549,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 199,
-                                                        "startColumn": 7
+                                                        "endLine": 199,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -9853,7 +10581,9 @@
                                 },
                                 "region": {
                                     "startLine": 199,
-                                    "startColumn": 17
+                                    "endLine": 199,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -9875,7 +10605,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 199,
-                                                        "startColumn": 17
+                                                        "endLine": 199,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -9905,7 +10637,9 @@
                                 },
                                 "region": {
                                     "startLine": 31,
-                                    "startColumn": 12
+                                    "endLine": 31,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -9927,7 +10661,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 31,
-                                                        "startColumn": 12
+                                                        "endLine": 31,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -9957,7 +10693,9 @@
                                 },
                                 "region": {
                                     "startLine": 49,
-                                    "startColumn": 6
+                                    "endLine": 49,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -9979,7 +10717,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 49,
-                                                        "startColumn": 6
+                                                        "endLine": 49,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -10009,7 +10749,9 @@
                                 },
                                 "region": {
                                     "startLine": 52,
-                                    "startColumn": 39
+                                    "endLine": 52,
+                                    "startColumn": 39,
+                                    "endColumn": 39
                                 }
                             }
                         }
@@ -10031,7 +10773,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 52,
-                                                        "startColumn": 39
+                                                        "endLine": 52,
+                                                        "startColumn": 39,
+                                                        "endColumn": 39
                                                     }
                                                 },
                                                 "message": {
@@ -10061,7 +10805,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 15
+                                    "endLine": 83,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -10083,7 +10829,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 15
+                                                        "endLine": 83,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -10113,7 +10861,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 31
+                                    "endLine": 83,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -10135,7 +10885,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 31
+                                                        "endLine": 83,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -10165,7 +10917,9 @@
                                 },
                                 "region": {
                                     "startLine": 89,
-                                    "startColumn": 12
+                                    "endLine": 89,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -10187,7 +10941,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 89,
-                                                        "startColumn": 12
+                                                        "endLine": 89,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -10217,7 +10973,9 @@
                                 },
                                 "region": {
                                     "startLine": 99,
-                                    "startColumn": 56
+                                    "endLine": 99,
+                                    "startColumn": 56,
+                                    "endColumn": 56
                                 }
                             }
                         }
@@ -10239,7 +10997,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 99,
-                                                        "startColumn": 56
+                                                        "endLine": 99,
+                                                        "startColumn": 56,
+                                                        "endColumn": 56
                                                     }
                                                 },
                                                 "message": {
@@ -10269,7 +11029,9 @@
                                 },
                                 "region": {
                                     "startLine": 101,
-                                    "startColumn": 59
+                                    "endLine": 101,
+                                    "startColumn": 59,
+                                    "endColumn": 59
                                 }
                             }
                         }
@@ -10291,7 +11053,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 101,
-                                                        "startColumn": 59
+                                                        "endLine": 101,
+                                                        "startColumn": 59,
+                                                        "endColumn": 59
                                                     }
                                                 },
                                                 "message": {
@@ -10321,7 +11085,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 17
+                                    "endLine": 127,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -10343,7 +11109,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 17
+                                                        "endLine": 127,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -10373,7 +11141,9 @@
                                 },
                                 "region": {
                                     "startLine": 132,
-                                    "startColumn": 12
+                                    "endLine": 132,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -10395,7 +11165,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 132,
-                                                        "startColumn": 12
+                                                        "endLine": 132,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -10425,7 +11197,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 37
+                                    "endLine": 75,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -10447,7 +11221,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 37
+                                                        "endLine": 75,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -10477,7 +11253,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 37
+                                    "endLine": 75,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -10499,7 +11277,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 37
+                                                        "endLine": 75,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -10529,7 +11309,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 38
+                                    "endLine": 75,
+                                    "startColumn": 38,
+                                    "endColumn": 38
                                 }
                             }
                         }
@@ -10551,7 +11333,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 38
+                                                        "endLine": 75,
+                                                        "startColumn": 38,
+                                                        "endColumn": 38
                                                     }
                                                 },
                                                 "message": {
@@ -10581,7 +11365,9 @@
                                 },
                                 "region": {
                                     "startLine": 77,
-                                    "startColumn": 38
+                                    "endLine": 77,
+                                    "startColumn": 38,
+                                    "endColumn": 38
                                 }
                             }
                         }
@@ -10603,7 +11389,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 77,
-                                                        "startColumn": 38
+                                                        "endLine": 77,
+                                                        "startColumn": 38,
+                                                        "endColumn": 38
                                                     }
                                                 },
                                                 "message": {
@@ -10633,7 +11421,9 @@
                                 },
                                 "region": {
                                     "startLine": 77,
-                                    "startColumn": 38
+                                    "endLine": 77,
+                                    "startColumn": 38,
+                                    "endColumn": 38
                                 }
                             }
                         }
@@ -10655,7 +11445,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 77,
-                                                        "startColumn": 38
+                                                        "endLine": 77,
+                                                        "startColumn": 38,
+                                                        "endColumn": 38
                                                     }
                                                 },
                                                 "message": {
@@ -10685,7 +11477,9 @@
                                 },
                                 "region": {
                                     "startLine": 77,
-                                    "startColumn": 39
+                                    "endLine": 77,
+                                    "startColumn": 39,
+                                    "endColumn": 39
                                 }
                             }
                         }
@@ -10707,7 +11501,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 77,
-                                                        "startColumn": 39
+                                                        "endLine": 77,
+                                                        "startColumn": 39,
+                                                        "endColumn": 39
                                                     }
                                                 },
                                                 "message": {
@@ -10737,7 +11533,9 @@
                                 },
                                 "region": {
                                     "startLine": 88,
-                                    "startColumn": 30
+                                    "endLine": 88,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -10759,7 +11557,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 88,
-                                                        "startColumn": 30
+                                                        "endLine": 88,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -10789,7 +11589,9 @@
                                 },
                                 "region": {
                                     "startLine": 88,
-                                    "startColumn": 30
+                                    "endLine": 88,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -10811,7 +11613,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 88,
-                                                        "startColumn": 30
+                                                        "endLine": 88,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -10841,7 +11645,9 @@
                                 },
                                 "region": {
                                     "startLine": 88,
-                                    "startColumn": 31
+                                    "endLine": 88,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -10863,7 +11669,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 88,
-                                                        "startColumn": 31
+                                                        "endLine": 88,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -10893,7 +11701,9 @@
                                 },
                                 "region": {
                                     "startLine": 99,
-                                    "startColumn": 23
+                                    "endLine": 99,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -10915,7 +11725,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 99,
-                                                        "startColumn": 23
+                                                        "endLine": 99,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -10945,7 +11757,9 @@
                                 },
                                 "region": {
                                     "startLine": 101,
-                                    "startColumn": 30
+                                    "endLine": 101,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -10967,7 +11781,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 101,
-                                                        "startColumn": 30
+                                                        "endLine": 101,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -10997,7 +11813,9 @@
                                 },
                                 "region": {
                                     "startLine": 104,
-                                    "startColumn": 30
+                                    "endLine": 104,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11019,7 +11837,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 104,
-                                                        "startColumn": 30
+                                                        "endLine": 104,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11049,7 +11869,9 @@
                                 },
                                 "region": {
                                     "startLine": 105,
-                                    "startColumn": 30
+                                    "endLine": 105,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11071,7 +11893,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 105,
-                                                        "startColumn": 30
+                                                        "endLine": 105,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11101,7 +11925,9 @@
                                 },
                                 "region": {
                                     "startLine": 35,
-                                    "startColumn": 6
+                                    "endLine": 35,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -11123,7 +11949,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 35,
-                                                        "startColumn": 6
+                                                        "endLine": 35,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -11153,7 +11981,9 @@
                                 },
                                 "region": {
                                     "startLine": 38,
-                                    "startColumn": 4
+                                    "endLine": 38,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -11175,7 +12005,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 38,
-                                                        "startColumn": 4
+                                                        "endLine": 38,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -11205,7 +12037,9 @@
                                 },
                                 "region": {
                                     "startLine": 42,
-                                    "startColumn": 1
+                                    "endLine": 42,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -11227,7 +12061,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 42,
-                                                        "startColumn": 1
+                                                        "endLine": 42,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -11257,7 +12093,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 13
+                                    "endLine": 63,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -11279,7 +12117,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 13
+                                                        "endLine": 63,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -11309,7 +12149,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 34
+                                    "endLine": 63,
+                                    "startColumn": 34,
+                                    "endColumn": 34
                                 }
                             }
                         }
@@ -11331,7 +12173,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 34
+                                                        "endLine": 63,
+                                                        "startColumn": 34,
+                                                        "endColumn": 34
                                                     }
                                                 },
                                                 "message": {
@@ -11361,7 +12205,9 @@
                                 },
                                 "region": {
                                     "startLine": 70,
-                                    "startColumn": 32
+                                    "endLine": 70,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -11383,7 +12229,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 70,
-                                                        "startColumn": 32
+                                                        "endLine": 70,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -11413,7 +12261,9 @@
                                 },
                                 "region": {
                                     "startLine": 70,
-                                    "startColumn": 43
+                                    "endLine": 70,
+                                    "startColumn": 43,
+                                    "endColumn": 43
                                 }
                             }
                         }
@@ -11435,7 +12285,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 70,
-                                                        "startColumn": 43
+                                                        "endLine": 70,
+                                                        "startColumn": 43,
+                                                        "endColumn": 43
                                                     }
                                                 },
                                                 "message": {
@@ -11465,7 +12317,9 @@
                                 },
                                 "region": {
                                     "startLine": 72,
-                                    "startColumn": 32
+                                    "endLine": 72,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -11487,7 +12341,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 72,
-                                                        "startColumn": 32
+                                                        "endLine": 72,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -11517,7 +12373,9 @@
                                 },
                                 "region": {
                                     "startLine": 72,
-                                    "startColumn": 43
+                                    "endLine": 72,
+                                    "startColumn": 43,
+                                    "endColumn": 43
                                 }
                             }
                         }
@@ -11539,7 +12397,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 72,
-                                                        "startColumn": 43
+                                                        "endLine": 72,
+                                                        "startColumn": 43,
+                                                        "endColumn": 43
                                                     }
                                                 },
                                                 "message": {
@@ -11569,7 +12429,9 @@
                                 },
                                 "region": {
                                     "startLine": 79,
-                                    "startColumn": 15
+                                    "endLine": 79,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -11591,7 +12453,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 79,
-                                                        "startColumn": 15
+                                                        "endLine": 79,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -11621,7 +12485,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 45
+                                    "endLine": 83,
+                                    "startColumn": 45,
+                                    "endColumn": 45
                                 }
                             }
                         }
@@ -11643,7 +12509,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 45
+                                                        "endLine": 83,
+                                                        "startColumn": 45,
+                                                        "endColumn": 45
                                                     }
                                                 },
                                                 "message": {
@@ -11673,7 +12541,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 26
+                                    "endLine": 84,
+                                    "startColumn": 26,
+                                    "endColumn": 26
                                 }
                             }
                         }
@@ -11695,7 +12565,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 26
+                                                        "endLine": 84,
+                                                        "startColumn": 26,
+                                                        "endColumn": 26
                                                     }
                                                 },
                                                 "message": {
@@ -11725,7 +12597,9 @@
                                 },
                                 "region": {
                                     "startLine": 31,
-                                    "startColumn": 12
+                                    "endLine": 31,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -11747,7 +12621,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 31,
-                                                        "startColumn": 12
+                                                        "endLine": 31,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -11777,7 +12653,9 @@
                                 },
                                 "region": {
                                     "startLine": 45,
-                                    "startColumn": 6
+                                    "endLine": 45,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -11799,7 +12677,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 45,
-                                                        "startColumn": 6
+                                                        "endLine": 45,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -11829,7 +12709,9 @@
                                 },
                                 "region": {
                                     "startLine": 47,
-                                    "startColumn": 9
+                                    "endLine": 47,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -11851,7 +12733,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 47,
-                                                        "startColumn": 9
+                                                        "endLine": 47,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -11881,7 +12765,9 @@
                                 },
                                 "region": {
                                     "startLine": 56,
-                                    "startColumn": 6
+                                    "endLine": 56,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -11903,7 +12789,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 56,
-                                                        "startColumn": 6
+                                                        "endLine": 56,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -11933,7 +12821,9 @@
                                 },
                                 "region": {
                                     "startLine": 61,
-                                    "startColumn": 33
+                                    "endLine": 61,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -11955,7 +12845,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 61,
-                                                        "startColumn": 33
+                                                        "endLine": 61,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -11985,7 +12877,9 @@
                                 },
                                 "region": {
                                     "startLine": 62,
-                                    "startColumn": 10
+                                    "endLine": 62,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -12007,7 +12901,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 62,
-                                                        "startColumn": 10
+                                                        "endLine": 62,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -12037,7 +12933,9 @@
                                 },
                                 "region": {
                                     "startLine": 65,
-                                    "startColumn": 17
+                                    "endLine": 65,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -12059,7 +12957,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 65,
-                                                        "startColumn": 17
+                                                        "endLine": 65,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -12089,7 +12989,9 @@
                                 },
                                 "region": {
                                     "startLine": 65,
-                                    "startColumn": 36
+                                    "endLine": 65,
+                                    "startColumn": 36,
+                                    "endColumn": 36
                                 }
                             }
                         }
@@ -12111,7 +13013,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 65,
-                                                        "startColumn": 36
+                                                        "endLine": 65,
+                                                        "startColumn": 36,
+                                                        "endColumn": 36
                                                     }
                                                 },
                                                 "message": {
@@ -12141,7 +13045,9 @@
                                 },
                                 "region": {
                                     "startLine": 80,
-                                    "startColumn": 6
+                                    "endLine": 80,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -12163,7 +13069,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 80,
-                                                        "startColumn": 6
+                                                        "endLine": 80,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {

--- a/tests/csgrep/0097-sarif-set-tool-stdout.txt
+++ b/tests/csgrep/0097-sarif-set-tool-stdout.txt
@@ -60,7 +60,9 @@
                                 },
                                 "region": {
                                     "startLine": 6,
-                                    "startColumn": 1
+                                    "endLine": 6,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -82,7 +84,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 6,
-                                                        "startColumn": 1
+                                                        "endLine": 6,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -112,7 +116,9 @@
                                 },
                                 "region": {
                                     "startLine": 4,
-                                    "startColumn": 7
+                                    "endLine": 4,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -134,7 +140,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4,
-                                                        "startColumn": 7
+                                                        "endLine": 4,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {

--- a/tests/csgrep/0098-json-parser-shellcheck-stdout.txt
+++ b/tests/csgrep/0098-json-parser-shellcheck-stdout.txt
@@ -26,6 +26,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 2,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[SC2155]",
                     "message": "Declare and assign separately to avoid masking return values.",
                     "verbosity_level": 0
@@ -42,6 +43,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 5,
                     "column": 8,
+                    "h_size": 4,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -58,6 +60,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 7,
                     "column": 31,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -74,6 +77,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 9,
                     "column": 33,
+                    "h_size": 8,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -90,6 +94,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 9,
                     "column": 56,
+                    "h_size": 13,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -106,6 +111,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 10,
                     "column": 33,
+                    "h_size": 8,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -122,6 +128,7 @@
                     "file_name": "tests/cssort/sync-diff.sh",
                     "line": 10,
                     "column": 56,
+                    "h_size": 13,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -138,6 +145,7 @@
                     "file_name": "tests/cslinker/0002-xml-parser/runtest.sh",
                     "line": 6,
                     "column": 3,
+                    "h_size": 33,
                     "event": "info[SC1091]",
                     "message": "Not following: ./../../test-lib.sh was not specified as input (see shellcheck -x).",
                     "verbosity_level": 0
@@ -154,6 +162,7 @@
                     "file_name": "tests/cslinker/0002-xml-parser/runtest.sh",
                     "line": 6,
                     "column": 3,
+                    "h_size": 15,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -170,6 +179,7 @@
                     "file_name": "tests/cslinker/0001-smoke/runtest.sh",
                     "line": 6,
                     "column": 3,
+                    "h_size": 33,
                     "event": "info[SC1091]",
                     "message": "Not following: ./../../test-lib.sh was not specified as input (see shellcheck -x).",
                     "verbosity_level": 0
@@ -186,6 +196,7 @@
                     "file_name": "tests/cslinker/0001-smoke/runtest.sh",
                     "line": 6,
                     "column": 3,
+                    "h_size": 15,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -218,6 +229,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 2,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[SC2155]",
                     "message": "Declare and assign separately to avoid masking return values.",
                     "verbosity_level": 0
@@ -234,6 +246,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 2,
                     "column": 16,
+                    "h_size": 43,
                     "event": "style[SC2006]",
                     "message": "Use $(...) notation instead of legacy backticked `...`.",
                     "verbosity_level": 0
@@ -250,6 +263,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 5,
                     "column": 8,
+                    "h_size": 2,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -266,6 +280,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 10,
                     "column": 24,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -282,6 +297,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 10,
                     "column": 39,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -298,6 +314,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 10,
                     "column": 56,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -314,6 +331,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 11,
                     "column": 24,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -330,6 +348,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 11,
                     "column": 39,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -346,6 +365,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 11,
                     "column": 56,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -362,6 +382,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 12,
                     "column": 24,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -378,6 +399,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 12,
                     "column": 39,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -394,6 +416,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 12,
                     "column": 56,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -410,6 +433,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 13,
                     "column": 24,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -426,6 +450,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 13,
                     "column": 39,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -442,6 +467,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 13,
                     "column": 56,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -458,6 +484,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 25,
                     "column": 25,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -474,6 +501,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 25,
                     "column": 44,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -490,6 +518,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 25,
                     "column": 59,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -506,6 +535,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 25,
                     "column": 76,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -522,6 +552,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 26,
                     "column": 25,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -538,6 +569,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 26,
                     "column": 44,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -554,6 +586,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 26,
                     "column": 59,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -570,6 +603,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 26,
                     "column": 76,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -586,6 +620,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 27,
                     "column": 25,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -602,6 +637,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 27,
                     "column": 44,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -618,6 +654,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 27,
                     "column": 59,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -634,6 +671,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 27,
                     "column": 76,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -650,6 +688,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 28,
                     "column": 25,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -666,6 +705,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 28,
                     "column": 44,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -682,6 +722,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 28,
                     "column": 59,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -698,6 +739,7 @@
                     "file_name": "tests/csdiff/sync-diff.sh",
                     "line": 28,
                     "column": 76,
+                    "h_size": 6,
                     "event": "info[SC2086]",
                     "message": "Double quote to prevent globbing and word splitting.",
                     "verbosity_level": 0
@@ -730,6 +772,7 @@
                     "file_name": "make-srpm.sh",
                     "line": 41,
                     "column": 8,
+                    "h_size": 29,
                     "event": "style[SC2001]",
                     "message": "See if you can use ${variable//search/replace} instead.",
                     "verbosity_level": 0
@@ -746,6 +789,7 @@
                     "file_name": "make-srpm.sh",
                     "line": 46,
                     "column": 8,
+                    "h_size": 40,
                     "event": "style[SC2001]",
                     "message": "See if you can use ${variable//search/replace} instead.",
                     "verbosity_level": 0
@@ -762,6 +806,7 @@
                     "file_name": "make-srpm.sh",
                     "line": 58,
                     "column": 19,
+                    "h_size": 4,
                     "event": "warning[SC2064]",
                     "message": "Use single quotes, otherwise this expands now rather than when signalled.",
                     "verbosity_level": 0

--- a/tests/csgrep/0100-sarif-parser-gitleaks-stdout.txt
+++ b/tests/csgrep/0100-sarif-parser-gitleaks-stdout.txt
@@ -12,6 +12,7 @@
                     "file_name": "/builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/build/lib/covscanhub/scan/fixtures/initial_data.json",
                     "line": 3039,
                     "column": 14,
+                    "h_size": 71,
                     "event": "warning[generic-api-key]",
                     "message": "generic-api-key has detected secret for file /builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/build/lib/covscanhub/scan/fixtures/initial_data.json.",
                     "verbosity_level": 0
@@ -27,6 +28,7 @@
                     "file_name": "/builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand-local.conf",
                     "line": 15,
                     "column": 9,
+                    "h_size": 71,
                     "event": "warning[generic-api-key]",
                     "message": "generic-api-key has detected secret for file /builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand-local.conf.",
                     "verbosity_level": 0
@@ -42,6 +44,7 @@
                     "file_name": "/builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand.conf",
                     "line": 15,
                     "column": 9,
+                    "h_size": 71,
                     "event": "warning[generic-api-key]",
                     "message": "generic-api-key has detected secret for file /builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand.conf.",
                     "verbosity_level": 0
@@ -57,6 +60,7 @@
                     "file_name": "/builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand.conf.prod",
                     "line": 15,
                     "column": 9,
+                    "h_size": 71,
                     "event": "warning[generic-api-key]",
                     "message": "generic-api-key has detected secret for file /builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand.conf.prod.",
                     "verbosity_level": 0
@@ -72,6 +76,7 @@
                     "file_name": "/builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand.conf.stage",
                     "line": 15,
                     "column": 9,
+                    "h_size": 71,
                     "event": "warning[generic-api-key]",
                     "message": "generic-api-key has detected secret for file /builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscand/covscand.conf.stage.",
                     "verbosity_level": 0
@@ -87,6 +92,7 @@
                     "file_name": "/builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscanhub/scan/fixtures/initial_data.json",
                     "line": 3039,
                     "column": 14,
+                    "h_size": 71,
                     "event": "warning[generic-api-key]",
                     "message": "generic-api-key has detected secret for file /builddir/build/BUILD/covscan-0.8.2.git.20221006.153904.67668dc/covscanhub/scan/fixtures/initial_data.json.",
                     "verbosity_level": 0

--- a/tests/csgrep/0106-snyk-prepend-path-stdout.txt
+++ b/tests/csgrep/0106-snyk-prepend-path-stdout.txt
@@ -13,6 +13,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 624,
                     "column": 39,
+                    "h_size": 4,
                     "event": "warning[cpp/DerefNull]",
                     "message": "(BETA Suggestion) A pointer is possibly assigned to NULL then used. NULL pointer use can lead to program crashes.",
                     "verbosity_level": 0
@@ -29,6 +30,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 788,
                     "column": 6,
+                    "h_size": 4,
                     "event": "warning[cpp/DerefNull]",
                     "message": "(BETA Suggestion) A pointer is possibly assigned the return value of a standard library function that may return NULL and is not checked before use. NULL pointer use can lead to program crashes.",
                     "verbosity_level": 0
@@ -45,6 +47,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 3898,
                     "column": 6,
+                    "h_size": 6,
                     "event": "warning[cpp/DerefNull]",
                     "message": "(BETA Suggestion) A pointer is possibly assigned the return value of a standard library function that may return NULL and is not checked before use. NULL pointer use can lead to program crashes.",
                     "verbosity_level": 0
@@ -61,6 +64,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5267,
                     "column": 13,
+                    "h_size": 33,
                     "event": "warning[cpp/DerefNull]",
                     "message": "(BETA Suggestion) A pointer is possibly assigned the return value of a standard library function that may return NULL and is not checked before use. NULL pointer use can lead to program crashes.",
                     "verbosity_level": 0
@@ -77,6 +81,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 519,
                     "column": 41,
+                    "h_size": 11,
                     "event": "warning[cpp/UserControlledPointer]",
                     "message": "(BETA Suggestion) User input from a file flows into pointer arithmetic, where it is used to set a pointer's address. As a result an attacker might be able to control where the pointer is pointing and either manipulate memory or expose values otherwise meant to be hidden.",
                     "verbosity_level": 0
@@ -93,6 +98,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 524,
                     "column": 20,
+                    "h_size": 11,
                     "event": "warning[cpp/UserControlledPointer]",
                     "message": "(BETA Suggestion) User input from a file flows into pointer arithmetic, where it is used to set a pointer's address. As a result an attacker might be able to control where the pointer is pointing and either manipulate memory or expose values otherwise meant to be hidden.",
                     "verbosity_level": 0
@@ -109,6 +115,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1145,
                     "column": 42,
+                    "h_size": 15,
                     "event": "warning[cpp/UserControlledPointer]",
                     "message": "(BETA Suggestion) User input from an environment variable flows into the & operator, where it is used to set a pointer's address. As a result an attacker might be able to control where the pointer is pointing and either manipulate memory or expose values otherwise meant to be hidden.",
                     "verbosity_level": 0
@@ -125,6 +132,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1146,
                     "column": 42,
+                    "h_size": 15,
                     "event": "warning[cpp/UserControlledPointer]",
                     "message": "(BETA Suggestion) User input from an environment variable flows into the & operator, where it is used to set a pointer's address. As a result an attacker might be able to control where the pointer is pointing and either manipulate memory or expose values otherwise meant to be hidden.",
                     "verbosity_level": 0
@@ -141,6 +149,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4122,
                     "column": 44,
+                    "h_size": 15,
                     "event": "warning[cpp/UserControlledPointer]",
                     "message": "(BETA Suggestion) User input from an environment variable flows into pointer arithmetic, where it is used to set a pointer's address. As a result an attacker might be able to control where the pointer is pointing and either manipulate memory or expose values otherwise meant to be hidden.",
                     "verbosity_level": 0
@@ -157,6 +166,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6169,
                     "column": 25,
+                    "h_size": 20,
                     "event": "warning[cpp/UserControlledPointer]",
                     "message": "(BETA Suggestion) User input from an environment variable flows into pointer arithmetic, where it is used to set a pointer's address. As a result an attacker might be able to control where the pointer is pointing and either manipulate memory or expose values otherwise meant to be hidden.",
                     "verbosity_level": 0
@@ -173,6 +183,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2113,
                     "column": 10,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -189,6 +200,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4125,
                     "column": 11,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -205,6 +217,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4317,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -221,6 +234,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4410,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -237,6 +251,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4423,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -253,6 +268,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4443,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -269,6 +285,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4523,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -285,6 +302,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4536,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -301,6 +319,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4584,
                     "column": 7,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -317,6 +336,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4659,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -333,6 +353,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5644,
                     "column": 9,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -349,6 +370,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5925,
                     "column": 9,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -365,6 +387,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6166,
                     "column": 8,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -381,6 +404,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6169,
                     "column": 8,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcpy, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -397,6 +421,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2115,
                     "column": 10,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcat, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -413,6 +438,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4411,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcat, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -429,6 +455,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4425,
                     "column": 5,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcat, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -445,6 +472,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4585,
                     "column": 7,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcat, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -461,6 +489,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6167,
                     "column": 8,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into strcat, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -477,6 +506,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6168,
                     "column": 8,
+                    "h_size": 6,
                     "event": "error[cpp/BufferOverflow]",
                     "message": "Unsanitized input from an environment variable flows into memset, where it is used . This may result in a buffer overflow vulnerability.",
                     "verbosity_level": 0
@@ -493,6 +523,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 364,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -509,6 +540,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 3644,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -525,6 +557,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 3720,
                     "column": 5,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -541,6 +574,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4805,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -557,6 +591,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4820,
                     "column": 9,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -573,6 +608,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4850,
                     "column": 11,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -589,6 +625,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4860,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -605,6 +642,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4863,
                     "column": 9,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -621,6 +659,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4886,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -637,6 +676,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5329,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSFILE) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -653,6 +693,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4827,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable HOME) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -669,6 +710,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4893,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable HOME) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -685,6 +727,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4908,
                     "column": 5,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable HOME) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -701,6 +744,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4879,
                     "column": 7,
+                    "h_size": 6,
                     "event": "note[cpp/SystemInformationLeak]",
                     "message": "System data (the environment variable UNITSLOCALEMAP) flows into printf. This information leak might help an attacker to gather information about the system and plan an attack.",
                     "verbosity_level": 0
@@ -717,6 +761,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 402,
                     "column": 12,
+                    "h_size": 4,
                     "event": "warning[cpp/TOCTOU]",
                     "message": "(BETA Suggestion) The state of the file at the path being checked could be changed before the later operation using the same file path. In between the check and access the file could be modified and lead to the program performing an unexpected file operation. Where possible, use functions that perform checks as they open files, or use file descriptors.",
                     "verbosity_level": 0
@@ -733,6 +778,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4600,
                     "column": 17,
+                    "h_size": 6,
                     "event": "error[cpp/MemoryManagementControl]",
                     "message": "Unsanitized input from an environment variable flows into malloc, where it is used to allocate memory. This may result in a denial of service attack. An attacker can attempt to allocate very large amounts of memory.",
                     "verbosity_level": 0
@@ -749,6 +795,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4604,
                     "column": 17,
+                    "h_size": 6,
                     "event": "error[cpp/MemoryManagementControl]",
                     "message": "Unsanitized input from an environment variable flows into malloc, where it is used to allocate memory. This may result in a denial of service attack. An attacker can attempt to allocate very large amounts of memory.",
                     "verbosity_level": 0
@@ -765,6 +812,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 587,
                     "column": 4,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -781,6 +829,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1541,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -797,6 +846,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1809,
                     "column": 15,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -813,6 +863,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1811,
                     "column": 15,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -829,6 +880,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1812,
                     "column": 15,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -845,6 +897,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2077,
                     "column": 10,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -861,6 +914,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2087,
                     "column": 13,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -877,6 +931,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2098,
                     "column": 13,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -893,6 +948,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2113,
                     "column": 10,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -909,6 +965,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 3123,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -925,6 +982,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4125,
                     "column": 11,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -941,6 +999,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4161,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -957,6 +1016,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4258,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -973,6 +1033,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4317,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -989,6 +1050,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4328,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1005,6 +1067,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4410,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1021,6 +1084,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4423,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1037,6 +1101,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4442,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1053,6 +1118,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4443,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1069,6 +1135,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4523,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1085,6 +1152,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4536,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1101,6 +1169,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4584,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1117,6 +1186,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4659,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1133,6 +1203,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5400,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1149,6 +1220,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5625,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1165,6 +1237,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5632,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1181,6 +1254,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5644,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1197,6 +1271,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5925,
                     "column": 9,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1213,6 +1288,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6166,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1229,6 +1305,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6169,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcpy can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncpy instead.",
                     "verbosity_level": 0
@@ -1245,6 +1322,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 1543,
                     "column": 3,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1261,6 +1339,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 2115,
                     "column": 10,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1277,6 +1356,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4126,
                     "column": 11,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1293,6 +1373,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4162,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1309,6 +1390,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4270,
                     "column": 11,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1325,6 +1407,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4411,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1341,6 +1424,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4424,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1357,6 +1441,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4425,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1373,6 +1458,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4524,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1389,6 +1475,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4537,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1405,6 +1492,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4538,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1421,6 +1509,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4585,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1437,6 +1526,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4662,
                     "column": 7,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1453,6 +1543,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4663,
                     "column": 5,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1469,6 +1560,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5627,
                     "column": 11,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1485,6 +1577,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 6167,
                     "column": 8,
+                    "h_size": 6,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using strcat can lead to severe buffer overflow vulnerabilities. Use the safe alternative strncat instead.",
                     "verbosity_level": 0
@@ -1501,6 +1594,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4601,
                     "column": 7,
+                    "h_size": 7,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1517,6 +1611,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 4605,
                     "column": 7,
+                    "h_size": 7,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0
@@ -1533,6 +1628,7 @@
                     "file_name": "/builddir/build/BUILD/units-2.22/units.c",
                     "line": 5845,
                     "column": 5,
+                    "h_size": 7,
                     "event": "warning[cpp/BufferOverflowUnsafeFunction]",
                     "message": "Using sprintf can lead to severe buffer overflow vulnerabilities. Use the safe alternative snprintf instead.",
                     "verbosity_level": 0

--- a/tests/csgrep/0109-shellcheck-sarif-cwe-stdout.txt
+++ b/tests/csgrep/0109-shellcheck-sarif-cwe-stdout.txt
@@ -446,7 +446,9 @@
                                 },
                                 "region": {
                                     "startLine": 6,
-                                    "startColumn": 1
+                                    "endLine": 6,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -468,7 +470,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 6,
-                                                        "startColumn": 1
+                                                        "endLine": 6,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -501,7 +505,9 @@
                                 },
                                 "region": {
                                     "startLine": 4,
-                                    "startColumn": 7
+                                    "endLine": 4,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -523,7 +529,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4,
-                                                        "startColumn": 7
+                                                        "endLine": 4,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -553,7 +561,9 @@
                                 },
                                 "region": {
                                     "startLine": 14,
-                                    "startColumn": 13
+                                    "endLine": 14,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -575,7 +585,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 14,
-                                                        "startColumn": 13
+                                                        "endLine": 14,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -605,7 +617,9 @@
                                 },
                                 "region": {
                                     "startLine": 15,
-                                    "startColumn": 25
+                                    "endLine": 15,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -627,7 +641,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 15,
-                                                        "startColumn": 25
+                                                        "endLine": 15,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -657,7 +673,9 @@
                                 },
                                 "region": {
                                     "startLine": 17,
-                                    "startColumn": 10
+                                    "endLine": 17,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -679,7 +697,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 17,
-                                                        "startColumn": 10
+                                                        "endLine": 17,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -709,7 +729,9 @@
                                 },
                                 "region": {
                                     "startLine": 18,
-                                    "startColumn": 14
+                                    "endLine": 18,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -731,7 +753,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 18,
-                                                        "startColumn": 14
+                                                        "endLine": 18,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -761,7 +785,9 @@
                                 },
                                 "region": {
                                     "startLine": 20,
-                                    "startColumn": 7
+                                    "endLine": 20,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -783,7 +809,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 20,
-                                                        "startColumn": 7
+                                                        "endLine": 20,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -813,7 +841,9 @@
                                 },
                                 "region": {
                                     "startLine": 20,
-                                    "startColumn": 44
+                                    "endLine": 20,
+                                    "startColumn": 44,
+                                    "endColumn": 44
                                 }
                             }
                         }
@@ -835,7 +865,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 20,
-                                                        "startColumn": 44
+                                                        "endLine": 20,
+                                                        "startColumn": 44,
+                                                        "endColumn": 44
                                                     }
                                                 },
                                                 "message": {
@@ -865,7 +897,9 @@
                                 },
                                 "region": {
                                     "startLine": 20,
-                                    "startColumn": 57
+                                    "endLine": 20,
+                                    "startColumn": 57,
+                                    "endColumn": 57
                                 }
                             }
                         }
@@ -887,7 +921,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 20,
-                                                        "startColumn": 57
+                                                        "endLine": 20,
+                                                        "startColumn": 57,
+                                                        "endColumn": 57
                                                     }
                                                 },
                                                 "message": {
@@ -920,7 +956,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 25
+                                    "endLine": 2,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -942,7 +980,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 25
+                                                        "endLine": 2,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -972,7 +1012,9 @@
                                 },
                                 "region": {
                                     "startLine": 21,
-                                    "startColumn": 3
+                                    "endLine": 21,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -994,7 +1036,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 21,
-                                                        "startColumn": 3
+                                                        "endLine": 21,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -1024,7 +1068,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1046,7 +1092,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1076,7 +1124,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1098,7 +1148,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1128,7 +1180,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1150,7 +1204,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1180,7 +1236,9 @@
                                 },
                                 "region": {
                                     "startLine": 6,
-                                    "startColumn": 6
+                                    "endLine": 6,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1202,7 +1260,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 6,
-                                                        "startColumn": 6
+                                                        "endLine": 6,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1232,7 +1292,9 @@
                                 },
                                 "region": {
                                     "startLine": 11,
-                                    "startColumn": 6
+                                    "endLine": 11,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -1254,7 +1316,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 11,
-                                                        "startColumn": 6
+                                                        "endLine": 11,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -1287,7 +1351,9 @@
                                 },
                                 "region": {
                                     "startLine": 34,
-                                    "startColumn": 7
+                                    "endLine": 34,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -1309,7 +1375,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 34,
-                                                        "startColumn": 7
+                                                        "endLine": 34,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -1342,7 +1410,9 @@
                                 },
                                 "region": {
                                     "startLine": 45,
-                                    "startColumn": 2
+                                    "endLine": 45,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -1364,7 +1434,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 45,
-                                                        "startColumn": 2
+                                                        "endLine": 45,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -1397,7 +1469,9 @@
                                 },
                                 "region": {
                                     "startLine": 60,
-                                    "startColumn": 3
+                                    "endLine": 60,
+                                    "startColumn": 3,
+                                    "endColumn": 3
                                 }
                             }
                         }
@@ -1419,7 +1493,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 60,
-                                                        "startColumn": 3
+                                                        "endLine": 60,
+                                                        "startColumn": 3,
+                                                        "endColumn": 3
                                                     }
                                                 },
                                                 "message": {
@@ -1449,7 +1525,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1471,7 +1549,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1501,7 +1581,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1523,7 +1605,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1553,7 +1637,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1575,7 +1661,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1605,7 +1693,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1627,7 +1717,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1657,7 +1749,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1679,7 +1773,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1709,7 +1805,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1731,7 +1829,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1761,7 +1861,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1783,7 +1885,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1813,7 +1917,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1835,7 +1941,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1865,7 +1973,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1887,7 +1997,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1917,7 +2029,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -1939,7 +2053,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -1972,7 +2088,9 @@
                                 },
                                 "region": {
                                     "startLine": 4,
-                                    "startColumn": 7
+                                    "endLine": 4,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -1994,7 +2112,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 4,
-                                                        "startColumn": 7
+                                                        "endLine": 4,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -2024,7 +2144,9 @@
                                 },
                                 "region": {
                                     "startLine": 5,
-                                    "startColumn": 7
+                                    "endLine": 5,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -2046,7 +2168,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 5,
-                                                        "startColumn": 7
+                                                        "endLine": 5,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -2076,7 +2200,9 @@
                                 },
                                 "region": {
                                     "startLine": 5,
-                                    "startColumn": 13
+                                    "endLine": 5,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -2098,7 +2224,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 5,
-                                                        "startColumn": 13
+                                                        "endLine": 5,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -2131,7 +2259,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 8
+                                    "endLine": 2,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -2153,7 +2283,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 8
+                                                        "endLine": 2,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -2186,7 +2318,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 23
+                                    "endLine": 2,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2208,7 +2342,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 23
+                                                        "endLine": 2,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2238,7 +2374,9 @@
                                 },
                                 "region": {
                                     "startLine": 2,
-                                    "startColumn": 23
+                                    "endLine": 2,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2260,7 +2398,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 2,
-                                                        "startColumn": 23
+                                                        "endLine": 2,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2293,7 +2433,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 8
+                                    "endLine": 3,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -2315,7 +2457,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 8
+                                                        "endLine": 3,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -2348,7 +2492,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 23
+                                    "endLine": 3,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2370,7 +2516,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 23
+                                                        "endLine": 3,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2400,7 +2548,9 @@
                                 },
                                 "region": {
                                     "startLine": 3,
-                                    "startColumn": 23
+                                    "endLine": 3,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -2422,7 +2572,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 3,
-                                                        "startColumn": 23
+                                                        "endLine": 3,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -2455,7 +2607,9 @@
                                 },
                                 "region": {
                                     "startLine": 27,
-                                    "startColumn": 47
+                                    "endLine": 27,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -2477,7 +2631,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 27,
-                                                        "startColumn": 47
+                                                        "endLine": 27,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -2507,7 +2663,9 @@
                                 },
                                 "region": {
                                     "startLine": 28,
-                                    "startColumn": 32
+                                    "endLine": 28,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -2529,7 +2687,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 28,
-                                                        "startColumn": 32
+                                                        "endLine": 28,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -2559,7 +2719,9 @@
                                 },
                                 "region": {
                                     "startLine": 29,
-                                    "startColumn": 67
+                                    "endLine": 29,
+                                    "startColumn": 67,
+                                    "endColumn": 67
                                 }
                             }
                         }
@@ -2581,7 +2743,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 29,
-                                                        "startColumn": 67
+                                                        "endLine": 29,
+                                                        "startColumn": 67,
+                                                        "endColumn": 67
                                                     }
                                                 },
                                                 "message": {
@@ -2614,7 +2778,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 31
+                                    "endLine": 32,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -2636,7 +2802,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 31
+                                                        "endLine": 32,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -2666,7 +2834,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 49
+                                    "endLine": 32,
+                                    "startColumn": 49,
+                                    "endColumn": 49
                                 }
                             }
                         }
@@ -2688,7 +2858,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 49
+                                                        "endLine": 32,
+                                                        "startColumn": 49,
+                                                        "endColumn": 49
                                                     }
                                                 },
                                                 "message": {
@@ -2721,7 +2893,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -2743,7 +2917,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -2773,7 +2949,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -2795,7 +2973,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -2825,7 +3005,9 @@
                                 },
                                 "region": {
                                     "startLine": 54,
-                                    "startColumn": 9
+                                    "endLine": 54,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -2847,7 +3029,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 54,
-                                                        "startColumn": 9
+                                                        "endLine": 54,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -2880,7 +3064,9 @@
                                 },
                                 "region": {
                                     "startLine": 10,
-                                    "startColumn": 15
+                                    "endLine": 10,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -2902,7 +3088,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 10,
-                                                        "startColumn": 15
+                                                        "endLine": 10,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -2935,7 +3123,9 @@
                                 },
                                 "region": {
                                     "startLine": 10,
-                                    "startColumn": 27
+                                    "endLine": 10,
+                                    "startColumn": 27,
+                                    "endColumn": 27
                                 }
                             }
                         }
@@ -2957,7 +3147,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 10,
-                                                        "startColumn": 27
+                                                        "endLine": 10,
+                                                        "startColumn": 27,
+                                                        "endColumn": 27
                                                     }
                                                 },
                                                 "message": {
@@ -2990,7 +3182,9 @@
                                 },
                                 "region": {
                                     "startLine": 22,
-                                    "startColumn": 20
+                                    "endLine": 22,
+                                    "startColumn": 20,
+                                    "endColumn": 20
                                 }
                             }
                         }
@@ -3012,7 +3206,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 22,
-                                                        "startColumn": 20
+                                                        "endLine": 22,
+                                                        "startColumn": 20,
+                                                        "endColumn": 20
                                                     }
                                                 },
                                                 "message": {
@@ -3042,7 +3238,9 @@
                                 },
                                 "region": {
                                     "startLine": 23,
-                                    "startColumn": 64
+                                    "endLine": 23,
+                                    "startColumn": 64,
+                                    "endColumn": 64
                                 }
                             }
                         }
@@ -3064,7 +3262,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 23,
-                                                        "startColumn": 64
+                                                        "endLine": 23,
+                                                        "startColumn": 64,
+                                                        "endColumn": 64
                                                     }
                                                 },
                                                 "message": {
@@ -3094,7 +3294,9 @@
                                 },
                                 "region": {
                                     "startLine": 35,
-                                    "startColumn": 19
+                                    "endLine": 35,
+                                    "startColumn": 19,
+                                    "endColumn": 19
                                 }
                             }
                         }
@@ -3116,7 +3318,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 35,
-                                                        "startColumn": 19
+                                                        "endLine": 35,
+                                                        "startColumn": 19,
+                                                        "endColumn": 19
                                                     }
                                                 },
                                                 "message": {
@@ -3146,7 +3350,9 @@
                                 },
                                 "region": {
                                     "startLine": 43,
-                                    "startColumn": 66
+                                    "endLine": 43,
+                                    "startColumn": 66,
+                                    "endColumn": 66
                                 }
                             }
                         }
@@ -3168,7 +3374,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 43,
-                                                        "startColumn": 66
+                                                        "endLine": 43,
+                                                        "startColumn": 66,
+                                                        "endColumn": 66
                                                     }
                                                 },
                                                 "message": {
@@ -3198,7 +3406,9 @@
                                 },
                                 "region": {
                                     "startLine": 49,
-                                    "startColumn": 70
+                                    "endLine": 49,
+                                    "startColumn": 70,
+                                    "endColumn": 70
                                 }
                             }
                         }
@@ -3220,7 +3430,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 49,
-                                                        "startColumn": 70
+                                                        "endLine": 49,
+                                                        "startColumn": 70,
+                                                        "endColumn": 70
                                                     }
                                                 },
                                                 "message": {
@@ -3253,7 +3465,9 @@
                                 },
                                 "region": {
                                     "startLine": 52,
-                                    "startColumn": 25
+                                    "endLine": 52,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -3275,7 +3489,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 52,
-                                                        "startColumn": 25
+                                                        "endLine": 52,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -3305,7 +3521,9 @@
                                 },
                                 "region": {
                                     "startLine": 65,
-                                    "startColumn": 95
+                                    "endLine": 65,
+                                    "startColumn": 95,
+                                    "endColumn": 95
                                 }
                             }
                         }
@@ -3327,7 +3545,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 65,
-                                                        "startColumn": 95
+                                                        "endLine": 65,
+                                                        "startColumn": 95,
+                                                        "endColumn": 95
                                                     }
                                                 },
                                                 "message": {
@@ -3357,7 +3577,9 @@
                                 },
                                 "region": {
                                     "startLine": 66,
-                                    "startColumn": 87
+                                    "endLine": 66,
+                                    "startColumn": 87,
+                                    "endColumn": 87
                                 }
                             }
                         }
@@ -3379,7 +3601,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 66,
-                                                        "startColumn": 87
+                                                        "endLine": 66,
+                                                        "startColumn": 87,
+                                                        "endColumn": 87
                                                     }
                                                 },
                                                 "message": {
@@ -3409,7 +3633,9 @@
                                 },
                                 "region": {
                                     "startLine": 67,
-                                    "startColumn": 69
+                                    "endLine": 67,
+                                    "startColumn": 69,
+                                    "endColumn": 69
                                 }
                             }
                         }
@@ -3431,7 +3657,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 67,
-                                                        "startColumn": 69
+                                                        "endLine": 67,
+                                                        "startColumn": 69,
+                                                        "endColumn": 69
                                                     }
                                                 },
                                                 "message": {
@@ -3464,7 +3692,9 @@
                                 },
                                 "region": {
                                     "startLine": 68,
-                                    "startColumn": 27
+                                    "endLine": 68,
+                                    "startColumn": 27,
+                                    "endColumn": 27
                                 }
                             }
                         }
@@ -3486,7 +3716,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 68,
-                                                        "startColumn": 27
+                                                        "endLine": 68,
+                                                        "startColumn": 27,
+                                                        "endColumn": 27
                                                     }
                                                 },
                                                 "message": {
@@ -3519,7 +3751,9 @@
                                 },
                                 "region": {
                                     "startLine": 69,
-                                    "startColumn": 33
+                                    "endLine": 69,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3541,7 +3775,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 69,
-                                                        "startColumn": 33
+                                                        "endLine": 69,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3574,7 +3810,9 @@
                                 },
                                 "region": {
                                     "startLine": 70,
-                                    "startColumn": 25
+                                    "endLine": 70,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -3596,7 +3834,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 70,
-                                                        "startColumn": 25
+                                                        "endLine": 70,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -3629,7 +3869,9 @@
                                 },
                                 "region": {
                                     "startLine": 72,
-                                    "startColumn": 33
+                                    "endLine": 72,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3651,7 +3893,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 72,
-                                                        "startColumn": 33
+                                                        "endLine": 72,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3684,7 +3928,9 @@
                                 },
                                 "region": {
                                     "startLine": 74,
-                                    "startColumn": 33
+                                    "endLine": 74,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3706,7 +3952,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 74,
-                                                        "startColumn": 33
+                                                        "endLine": 74,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3739,7 +3987,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 33
+                                    "endLine": 75,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3761,7 +4011,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 33
+                                                        "endLine": 75,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3794,7 +4046,9 @@
                                 },
                                 "region": {
                                     "startLine": 76,
-                                    "startColumn": 33
+                                    "endLine": 76,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -3816,7 +4070,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 76,
-                                                        "startColumn": 33
+                                                        "endLine": 76,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -3846,7 +4102,9 @@
                                 },
                                 "region": {
                                     "startLine": 79,
-                                    "startColumn": 87
+                                    "endLine": 79,
+                                    "startColumn": 87,
+                                    "endColumn": 87
                                 }
                             }
                         }
@@ -3868,7 +4126,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 79,
-                                                        "startColumn": 87
+                                                        "endLine": 79,
+                                                        "startColumn": 87,
+                                                        "endColumn": 87
                                                     }
                                                 },
                                                 "message": {
@@ -3898,7 +4158,9 @@
                                 },
                                 "region": {
                                     "startLine": 81,
-                                    "startColumn": 89
+                                    "endLine": 81,
+                                    "startColumn": 89,
+                                    "endColumn": 89
                                 }
                             }
                         }
@@ -3920,7 +4182,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 81,
-                                                        "startColumn": 89
+                                                        "endLine": 81,
+                                                        "startColumn": 89,
+                                                        "endColumn": 89
                                                     }
                                                 },
                                                 "message": {
@@ -3950,7 +4214,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 86
+                                    "endLine": 83,
+                                    "startColumn": 86,
+                                    "endColumn": 86
                                 }
                             }
                         }
@@ -3972,7 +4238,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 86
+                                                        "endLine": 83,
+                                                        "startColumn": 86,
+                                                        "endColumn": 86
                                                     }
                                                 },
                                                 "message": {
@@ -4002,7 +4270,9 @@
                                 },
                                 "region": {
                                     "startLine": 85,
-                                    "startColumn": 98
+                                    "endLine": 85,
+                                    "startColumn": 98,
+                                    "endColumn": 98
                                 }
                             }
                         }
@@ -4024,7 +4294,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 85,
-                                                        "startColumn": 98
+                                                        "endLine": 85,
+                                                        "startColumn": 98,
+                                                        "endColumn": 98
                                                     }
                                                 },
                                                 "message": {
@@ -4054,7 +4326,9 @@
                                 },
                                 "region": {
                                     "startLine": 87,
-                                    "startColumn": 88
+                                    "endLine": 87,
+                                    "startColumn": 88,
+                                    "endColumn": 88
                                 }
                             }
                         }
@@ -4076,7 +4350,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 87,
-                                                        "startColumn": 88
+                                                        "endLine": 87,
+                                                        "startColumn": 88,
+                                                        "endColumn": 88
                                                     }
                                                 },
                                                 "message": {
@@ -4109,7 +4385,9 @@
                                 },
                                 "region": {
                                     "startLine": 89,
-                                    "startColumn": 33
+                                    "endLine": 89,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4131,7 +4409,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 89,
-                                                        "startColumn": 33
+                                                        "endLine": 89,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4164,7 +4444,9 @@
                                 },
                                 "region": {
                                     "startLine": 90,
-                                    "startColumn": 33
+                                    "endLine": 90,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4186,7 +4468,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 90,
-                                                        "startColumn": 33
+                                                        "endLine": 90,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4219,7 +4503,9 @@
                                 },
                                 "region": {
                                     "startLine": 94,
-                                    "startColumn": 33
+                                    "endLine": 94,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4241,7 +4527,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 94,
-                                                        "startColumn": 33
+                                                        "endLine": 94,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4274,7 +4562,9 @@
                                 },
                                 "region": {
                                     "startLine": 96,
-                                    "startColumn": 33
+                                    "endLine": 96,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4296,7 +4586,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 96,
-                                                        "startColumn": 33
+                                                        "endLine": 96,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4326,7 +4618,9 @@
                                 },
                                 "region": {
                                     "startLine": 99,
-                                    "startColumn": 17
+                                    "endLine": 99,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -4348,7 +4642,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 99,
-                                                        "startColumn": 17
+                                                        "endLine": 99,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -4381,7 +4677,9 @@
                                 },
                                 "region": {
                                     "startLine": 105,
-                                    "startColumn": 21
+                                    "endLine": 105,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -4403,7 +4701,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 105,
-                                                        "startColumn": 21
+                                                        "endLine": 105,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -4436,7 +4736,9 @@
                                 },
                                 "region": {
                                     "startLine": 106,
-                                    "startColumn": 21
+                                    "endLine": 106,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -4458,7 +4760,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 106,
-                                                        "startColumn": 21
+                                                        "endLine": 106,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -4491,7 +4795,9 @@
                                 },
                                 "region": {
                                     "startLine": 108,
-                                    "startColumn": 33
+                                    "endLine": 108,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4513,7 +4819,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 108,
-                                                        "startColumn": 33
+                                                        "endLine": 108,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4546,7 +4854,9 @@
                                 },
                                 "region": {
                                     "startLine": 109,
-                                    "startColumn": 33
+                                    "endLine": 109,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -4568,7 +4878,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 109,
-                                                        "startColumn": 33
+                                                        "endLine": 109,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -4601,7 +4913,9 @@
                                 },
                                 "region": {
                                     "startLine": 116,
-                                    "startColumn": 4
+                                    "endLine": 116,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -4623,7 +4937,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 116,
-                                                        "startColumn": 4
+                                                        "endLine": 116,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -4656,7 +4972,9 @@
                                 },
                                 "region": {
                                     "startLine": 118,
-                                    "startColumn": 34
+                                    "endLine": 118,
+                                    "startColumn": 34,
+                                    "endColumn": 34
                                 }
                             }
                         }
@@ -4678,7 +4996,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 118,
-                                                        "startColumn": 34
+                                                        "endLine": 118,
+                                                        "startColumn": 34,
+                                                        "endColumn": 34
                                                     }
                                                 },
                                                 "message": {
@@ -4711,7 +5031,9 @@
                                 },
                                 "region": {
                                     "startLine": 118,
-                                    "startColumn": 39
+                                    "endLine": 118,
+                                    "startColumn": 39,
+                                    "endColumn": 39
                                 }
                             }
                         }
@@ -4733,7 +5055,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 118,
-                                                        "startColumn": 39
+                                                        "endLine": 118,
+                                                        "startColumn": 39,
+                                                        "endColumn": 39
                                                     }
                                                 },
                                                 "message": {
@@ -4763,7 +5087,9 @@
                                 },
                                 "region": {
                                     "startLine": 124,
-                                    "startColumn": 99
+                                    "endLine": 124,
+                                    "startColumn": 99,
+                                    "endColumn": 99
                                 }
                             }
                         }
@@ -4785,7 +5111,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 124,
-                                                        "startColumn": 99
+                                                        "endLine": 124,
+                                                        "startColumn": 99,
+                                                        "endColumn": 99
                                                     }
                                                 },
                                                 "message": {
@@ -4815,7 +5143,9 @@
                                 },
                                 "region": {
                                     "startLine": 125,
-                                    "startColumn": 91
+                                    "endLine": 125,
+                                    "startColumn": 91,
+                                    "endColumn": 91
                                 }
                             }
                         }
@@ -4837,7 +5167,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 125,
-                                                        "startColumn": 91
+                                                        "endLine": 125,
+                                                        "startColumn": 91,
+                                                        "endColumn": 91
                                                     }
                                                 },
                                                 "message": {
@@ -4867,7 +5199,9 @@
                                 },
                                 "region": {
                                     "startLine": 126,
-                                    "startColumn": 73
+                                    "endLine": 126,
+                                    "startColumn": 73,
+                                    "endColumn": 73
                                 }
                             }
                         }
@@ -4889,7 +5223,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 126,
-                                                        "startColumn": 73
+                                                        "endLine": 126,
+                                                        "startColumn": 73,
+                                                        "endColumn": 73
                                                     }
                                                 },
                                                 "message": {
@@ -4922,7 +5258,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 31
+                                    "endLine": 127,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -4944,7 +5282,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 31
+                                                        "endLine": 127,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -4977,7 +5317,9 @@
                                 },
                                 "region": {
                                     "startLine": 128,
-                                    "startColumn": 37
+                                    "endLine": 128,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -4999,7 +5341,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 128,
-                                                        "startColumn": 37
+                                                        "endLine": 128,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5032,7 +5376,9 @@
                                 },
                                 "region": {
                                     "startLine": 129,
-                                    "startColumn": 29
+                                    "endLine": 129,
+                                    "startColumn": 29,
+                                    "endColumn": 29
                                 }
                             }
                         }
@@ -5054,7 +5400,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 129,
-                                                        "startColumn": 29
+                                                        "endLine": 129,
+                                                        "startColumn": 29,
+                                                        "endColumn": 29
                                                     }
                                                 },
                                                 "message": {
@@ -5087,7 +5435,9 @@
                                 },
                                 "region": {
                                     "startLine": 131,
-                                    "startColumn": 37
+                                    "endLine": 131,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5109,7 +5459,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 131,
-                                                        "startColumn": 37
+                                                        "endLine": 131,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5142,7 +5494,9 @@
                                 },
                                 "region": {
                                     "startLine": 133,
-                                    "startColumn": 37
+                                    "endLine": 133,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5164,7 +5518,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 133,
-                                                        "startColumn": 37
+                                                        "endLine": 133,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5197,7 +5553,9 @@
                                 },
                                 "region": {
                                     "startLine": 134,
-                                    "startColumn": 37
+                                    "endLine": 134,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5219,7 +5577,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 134,
-                                                        "startColumn": 37
+                                                        "endLine": 134,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5252,7 +5612,9 @@
                                 },
                                 "region": {
                                     "startLine": 135,
-                                    "startColumn": 37
+                                    "endLine": 135,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5274,7 +5636,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 135,
-                                                        "startColumn": 37
+                                                        "endLine": 135,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5304,7 +5668,9 @@
                                 },
                                 "region": {
                                     "startLine": 138,
-                                    "startColumn": 91
+                                    "endLine": 138,
+                                    "startColumn": 91,
+                                    "endColumn": 91
                                 }
                             }
                         }
@@ -5326,7 +5692,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 138,
-                                                        "startColumn": 91
+                                                        "endLine": 138,
+                                                        "startColumn": 91,
+                                                        "endColumn": 91
                                                     }
                                                 },
                                                 "message": {
@@ -5356,7 +5724,9 @@
                                 },
                                 "region": {
                                     "startLine": 140,
-                                    "startColumn": 93
+                                    "endLine": 140,
+                                    "startColumn": 93,
+                                    "endColumn": 93
                                 }
                             }
                         }
@@ -5378,7 +5748,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 140,
-                                                        "startColumn": 93
+                                                        "endLine": 140,
+                                                        "startColumn": 93,
+                                                        "endColumn": 93
                                                     }
                                                 },
                                                 "message": {
@@ -5408,7 +5780,9 @@
                                 },
                                 "region": {
                                     "startLine": 142,
-                                    "startColumn": 90
+                                    "endLine": 142,
+                                    "startColumn": 90,
+                                    "endColumn": 90
                                 }
                             }
                         }
@@ -5430,7 +5804,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 142,
-                                                        "startColumn": 90
+                                                        "endLine": 142,
+                                                        "startColumn": 90,
+                                                        "endColumn": 90
                                                     }
                                                 },
                                                 "message": {
@@ -5460,7 +5836,9 @@
                                 },
                                 "region": {
                                     "startLine": 144,
-                                    "startColumn": 102
+                                    "endLine": 144,
+                                    "startColumn": 102,
+                                    "endColumn": 102
                                 }
                             }
                         }
@@ -5482,7 +5860,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 144,
-                                                        "startColumn": 102
+                                                        "endLine": 144,
+                                                        "startColumn": 102,
+                                                        "endColumn": 102
                                                     }
                                                 },
                                                 "message": {
@@ -5512,7 +5892,9 @@
                                 },
                                 "region": {
                                     "startLine": 146,
-                                    "startColumn": 92
+                                    "endLine": 146,
+                                    "startColumn": 92,
+                                    "endColumn": 92
                                 }
                             }
                         }
@@ -5534,7 +5916,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 146,
-                                                        "startColumn": 92
+                                                        "endLine": 146,
+                                                        "startColumn": 92,
+                                                        "endColumn": 92
                                                     }
                                                 },
                                                 "message": {
@@ -5567,7 +5951,9 @@
                                 },
                                 "region": {
                                     "startLine": 148,
-                                    "startColumn": 37
+                                    "endLine": 148,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5589,7 +5975,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 148,
-                                                        "startColumn": 37
+                                                        "endLine": 148,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5622,7 +6010,9 @@
                                 },
                                 "region": {
                                     "startLine": 149,
-                                    "startColumn": 37
+                                    "endLine": 149,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5644,7 +6034,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 149,
-                                                        "startColumn": 37
+                                                        "endLine": 149,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5677,7 +6069,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 37
+                                    "endLine": 153,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5699,7 +6093,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 37
+                                                        "endLine": 153,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5732,7 +6128,9 @@
                                 },
                                 "region": {
                                     "startLine": 155,
-                                    "startColumn": 37
+                                    "endLine": 155,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5754,7 +6152,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 155,
-                                                        "startColumn": 37
+                                                        "endLine": 155,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -5784,7 +6184,9 @@
                                 },
                                 "region": {
                                     "startLine": 158,
-                                    "startColumn": 21
+                                    "endLine": 158,
+                                    "startColumn": 21,
+                                    "endColumn": 21
                                 }
                             }
                         }
@@ -5806,7 +6208,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 158,
-                                                        "startColumn": 21
+                                                        "endLine": 158,
+                                                        "startColumn": 21,
+                                                        "endColumn": 21
                                                     }
                                                 },
                                                 "message": {
@@ -5839,7 +6243,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 25
+                                    "endLine": 164,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -5861,7 +6267,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 25
+                                                        "endLine": 164,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -5894,7 +6302,9 @@
                                 },
                                 "region": {
                                     "startLine": 165,
-                                    "startColumn": 25
+                                    "endLine": 165,
+                                    "startColumn": 25,
+                                    "endColumn": 25
                                 }
                             }
                         }
@@ -5916,7 +6326,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 165,
-                                                        "startColumn": 25
+                                                        "endLine": 165,
+                                                        "startColumn": 25,
+                                                        "endColumn": 25
                                                     }
                                                 },
                                                 "message": {
@@ -5949,7 +6361,9 @@
                                 },
                                 "region": {
                                     "startLine": 167,
-                                    "startColumn": 37
+                                    "endLine": 167,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -5971,7 +6385,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 167,
-                                                        "startColumn": 37
+                                                        "endLine": 167,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -6004,7 +6420,9 @@
                                 },
                                 "region": {
                                     "startLine": 172,
-                                    "startColumn": 55
+                                    "endLine": 172,
+                                    "startColumn": 55,
+                                    "endColumn": 55
                                 }
                             }
                         }
@@ -6026,7 +6444,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 172,
-                                                        "startColumn": 55
+                                                        "endLine": 172,
+                                                        "startColumn": 55,
+                                                        "endColumn": 55
                                                     }
                                                 },
                                                 "message": {
@@ -6056,7 +6476,9 @@
                                 },
                                 "region": {
                                     "startLine": 173,
-                                    "startColumn": 100
+                                    "endLine": 173,
+                                    "startColumn": 100,
+                                    "endColumn": 100
                                 }
                             }
                         }
@@ -6078,7 +6500,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 173,
-                                                        "startColumn": 100
+                                                        "endLine": 173,
+                                                        "startColumn": 100,
+                                                        "endColumn": 100
                                                     }
                                                 },
                                                 "message": {
@@ -6111,7 +6535,9 @@
                                 },
                                 "region": {
                                     "startLine": 174,
-                                    "startColumn": 55
+                                    "endLine": 174,
+                                    "startColumn": 55,
+                                    "endColumn": 55
                                 }
                             }
                         }
@@ -6133,7 +6559,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 174,
-                                                        "startColumn": 55
+                                                        "endLine": 174,
+                                                        "startColumn": 55,
+                                                        "endColumn": 55
                                                     }
                                                 },
                                                 "message": {
@@ -6166,7 +6594,9 @@
                                 },
                                 "region": {
                                     "startLine": 179,
-                                    "startColumn": 55
+                                    "endLine": 179,
+                                    "startColumn": 55,
+                                    "endColumn": 55
                                 }
                             }
                         }
@@ -6188,7 +6618,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 179,
-                                                        "startColumn": 55
+                                                        "endLine": 179,
+                                                        "startColumn": 55,
+                                                        "endColumn": 55
                                                     }
                                                 },
                                                 "message": {
@@ -6221,7 +6653,9 @@
                                 },
                                 "region": {
                                     "startLine": 27,
-                                    "startColumn": 47
+                                    "endLine": 27,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -6243,7 +6677,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 27,
-                                                        "startColumn": 47
+                                                        "endLine": 27,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -6273,7 +6709,9 @@
                                 },
                                 "region": {
                                     "startLine": 28,
-                                    "startColumn": 32
+                                    "endLine": 28,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -6295,7 +6733,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 28,
-                                                        "startColumn": 32
+                                                        "endLine": 28,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -6325,7 +6765,9 @@
                                 },
                                 "region": {
                                     "startLine": 29,
-                                    "startColumn": 67
+                                    "endLine": 29,
+                                    "startColumn": 67,
+                                    "endColumn": 67
                                 }
                             }
                         }
@@ -6347,7 +6789,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 29,
-                                                        "startColumn": 67
+                                                        "endLine": 29,
+                                                        "startColumn": 67,
+                                                        "endColumn": 67
                                                     }
                                                 },
                                                 "message": {
@@ -6380,7 +6824,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 31
+                                    "endLine": 32,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -6402,7 +6848,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 31
+                                                        "endLine": 32,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -6432,7 +6880,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 49
+                                    "endLine": 32,
+                                    "startColumn": 49,
+                                    "endColumn": 49
                                 }
                             }
                         }
@@ -6454,7 +6904,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 49
+                                                        "endLine": 32,
+                                                        "startColumn": 49,
+                                                        "endColumn": 49
                                                     }
                                                 },
                                                 "message": {
@@ -6487,7 +6939,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -6509,7 +6963,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -6539,7 +6995,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 9
+                                    "endLine": 41,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -6561,7 +7019,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 9
+                                                        "endLine": 41,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -6591,7 +7051,9 @@
                                 },
                                 "region": {
                                     "startLine": 54,
-                                    "startColumn": 9
+                                    "endLine": 54,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -6613,7 +7075,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 54,
-                                                        "startColumn": 9
+                                                        "endLine": 54,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -6646,7 +7110,9 @@
                                 },
                                 "region": {
                                     "startLine": 10,
-                                    "startColumn": 23
+                                    "endLine": 10,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -6668,7 +7134,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 10,
-                                                        "startColumn": 23
+                                                        "endLine": 10,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -6701,7 +7169,9 @@
                                 },
                                 "region": {
                                     "startLine": 14,
-                                    "startColumn": 6
+                                    "endLine": 14,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6723,7 +7193,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 14,
-                                                        "startColumn": 6
+                                                        "endLine": 14,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6753,7 +7225,9 @@
                                 },
                                 "region": {
                                     "startLine": 16,
-                                    "startColumn": 6
+                                    "endLine": 16,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -6775,7 +7249,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 16,
-                                                        "startColumn": 6
+                                                        "endLine": 16,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -6808,7 +7284,9 @@
                                 },
                                 "region": {
                                     "startLine": 27,
-                                    "startColumn": 47
+                                    "endLine": 27,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -6830,7 +7308,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 27,
-                                                        "startColumn": 47
+                                                        "endLine": 27,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -6860,7 +7340,9 @@
                                 },
                                 "region": {
                                     "startLine": 28,
-                                    "startColumn": 32
+                                    "endLine": 28,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -6882,7 +7364,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 28,
-                                                        "startColumn": 32
+                                                        "endLine": 28,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -6912,7 +7396,9 @@
                                 },
                                 "region": {
                                     "startLine": 29,
-                                    "startColumn": 67
+                                    "endLine": 29,
+                                    "startColumn": 67,
+                                    "endColumn": 67
                                 }
                             }
                         }
@@ -6934,7 +7420,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 29,
-                                                        "startColumn": 67
+                                                        "endLine": 29,
+                                                        "startColumn": 67,
+                                                        "endColumn": 67
                                                     }
                                                 },
                                                 "message": {
@@ -6967,7 +7455,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 31
+                                    "endLine": 32,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -6989,7 +7479,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 31
+                                                        "endLine": 32,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -7019,7 +7511,9 @@
                                 },
                                 "region": {
                                     "startLine": 32,
-                                    "startColumn": 49
+                                    "endLine": 32,
+                                    "startColumn": 49,
+                                    "endColumn": 49
                                 }
                             }
                         }
@@ -7041,7 +7535,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 32,
-                                                        "startColumn": 49
+                                                        "endLine": 32,
+                                                        "startColumn": 49,
+                                                        "endColumn": 49
                                                     }
                                                 },
                                                 "message": {
@@ -7074,7 +7570,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 11
+                                    "endLine": 41,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -7096,7 +7594,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 11
+                                                        "endLine": 41,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -7126,7 +7626,9 @@
                                 },
                                 "region": {
                                     "startLine": 41,
-                                    "startColumn": 11
+                                    "endLine": 41,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -7148,7 +7650,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 41,
-                                                        "startColumn": 11
+                                                        "endLine": 41,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -7178,7 +7682,9 @@
                                 },
                                 "region": {
                                     "startLine": 59,
-                                    "startColumn": 14
+                                    "endLine": 59,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -7200,7 +7706,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 59,
-                                                        "startColumn": 14
+                                                        "endLine": 59,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -7230,7 +7738,9 @@
                                 },
                                 "region": {
                                     "startLine": 60,
-                                    "startColumn": 14
+                                    "endLine": 60,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -7252,7 +7762,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 60,
-                                                        "startColumn": 14
+                                                        "endLine": 60,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -7282,7 +7794,9 @@
                                 },
                                 "region": {
                                     "startLine": 61,
-                                    "startColumn": 20
+                                    "endLine": 61,
+                                    "startColumn": 20,
+                                    "endColumn": 20
                                 }
                             }
                         }
@@ -7304,7 +7818,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 61,
-                                                        "startColumn": 20
+                                                        "endLine": 61,
+                                                        "startColumn": 20,
+                                                        "endColumn": 20
                                                     }
                                                 },
                                                 "message": {
@@ -7334,7 +7850,9 @@
                                 },
                                 "region": {
                                     "startLine": 62,
-                                    "startColumn": 17
+                                    "endLine": 62,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -7356,7 +7874,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 62,
-                                                        "startColumn": 17
+                                                        "endLine": 62,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -7386,7 +7906,9 @@
                                 },
                                 "region": {
                                     "startLine": 71,
-                                    "startColumn": 9
+                                    "endLine": 71,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7408,7 +7930,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 71,
-                                                        "startColumn": 9
+                                                        "endLine": 71,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7438,7 +7962,9 @@
                                 },
                                 "region": {
                                     "startLine": 22,
-                                    "startColumn": 9
+                                    "endLine": 22,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7460,7 +7986,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 22,
-                                                        "startColumn": 9
+                                                        "endLine": 22,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7490,7 +8018,9 @@
                                 },
                                 "region": {
                                     "startLine": 34,
-                                    "startColumn": 9
+                                    "endLine": 34,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7512,7 +8042,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 34,
-                                                        "startColumn": 9
+                                                        "endLine": 34,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7542,7 +8074,9 @@
                                 },
                                 "region": {
                                     "startLine": 39,
-                                    "startColumn": 9
+                                    "endLine": 39,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -7564,7 +8098,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 39,
-                                                        "startColumn": 9
+                                                        "endLine": 39,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -7594,7 +8130,9 @@
                                 },
                                 "region": {
                                     "startLine": 61,
-                                    "startColumn": 1
+                                    "endLine": 61,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -7616,7 +8154,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 61,
-                                                        "startColumn": 1
+                                                        "endLine": 61,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -7646,7 +8186,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 6
+                                    "endLine": 63,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -7668,7 +8210,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 6
+                                                        "endLine": 63,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -7698,7 +8242,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 7
+                                    "endLine": 63,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -7720,7 +8266,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 7
+                                                        "endLine": 63,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -7750,7 +8298,9 @@
                                 },
                                 "region": {
                                     "startLine": 73,
-                                    "startColumn": 5
+                                    "endLine": 73,
+                                    "startColumn": 5,
+                                    "endColumn": 5
                                 }
                             }
                         }
@@ -7772,7 +8322,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 73,
-                                                        "startColumn": 5
+                                                        "endLine": 73,
+                                                        "startColumn": 5,
+                                                        "endColumn": 5
                                                     }
                                                 },
                                                 "message": {
@@ -7802,7 +8354,9 @@
                                 },
                                 "region": {
                                     "startLine": 73,
-                                    "startColumn": 8
+                                    "endLine": 73,
+                                    "startColumn": 8,
+                                    "endColumn": 8
                                 }
                             }
                         }
@@ -7824,7 +8378,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 73,
-                                                        "startColumn": 8
+                                                        "endLine": 73,
+                                                        "startColumn": 8,
+                                                        "endColumn": 8
                                                     }
                                                 },
                                                 "message": {
@@ -7854,7 +8410,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 2
+                                    "endLine": 84,
+                                    "startColumn": 2,
+                                    "endColumn": 2
                                 }
                             }
                         }
@@ -7876,7 +8434,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 2
+                                                        "endLine": 84,
+                                                        "startColumn": 2,
+                                                        "endColumn": 2
                                                     }
                                                 },
                                                 "message": {
@@ -7906,7 +8466,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 7
+                                    "endLine": 84,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -7928,7 +8490,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 7
+                                                        "endLine": 84,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -7958,7 +8522,9 @@
                                 },
                                 "region": {
                                     "startLine": 89,
-                                    "startColumn": 31
+                                    "endLine": 89,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -7980,7 +8546,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 89,
-                                                        "startColumn": 31
+                                                        "endLine": 89,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -8010,7 +8578,9 @@
                                 },
                                 "region": {
                                     "startLine": 94,
-                                    "startColumn": 10
+                                    "endLine": 94,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -8032,7 +8602,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 94,
-                                                        "startColumn": 10
+                                                        "endLine": 94,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -8062,7 +8634,9 @@
                                 },
                                 "region": {
                                     "startLine": 100,
-                                    "startColumn": 15
+                                    "endLine": 100,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -8084,7 +8658,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 100,
-                                                        "startColumn": 15
+                                                        "endLine": 100,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -8114,7 +8690,9 @@
                                 },
                                 "region": {
                                     "startLine": 100,
-                                    "startColumn": 23
+                                    "endLine": 100,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -8136,7 +8714,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 100,
-                                                        "startColumn": 23
+                                                        "endLine": 100,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -8166,7 +8746,9 @@
                                 },
                                 "region": {
                                     "startLine": 100,
-                                    "startColumn": 29
+                                    "endLine": 100,
+                                    "startColumn": 29,
+                                    "endColumn": 29
                                 }
                             }
                         }
@@ -8188,7 +8770,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 100,
-                                                        "startColumn": 29
+                                                        "endLine": 100,
+                                                        "startColumn": 29,
+                                                        "endColumn": 29
                                                     }
                                                 },
                                                 "message": {
@@ -8218,7 +8802,9 @@
                                 },
                                 "region": {
                                     "startLine": 102,
-                                    "startColumn": 9
+                                    "endLine": 102,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -8240,7 +8826,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 102,
-                                                        "startColumn": 9
+                                                        "endLine": 102,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -8270,7 +8858,9 @@
                                 },
                                 "region": {
                                     "startLine": 102,
-                                    "startColumn": 10
+                                    "endLine": 102,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -8292,7 +8882,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 102,
-                                                        "startColumn": 10
+                                                        "endLine": 102,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -8322,7 +8914,9 @@
                                 },
                                 "region": {
                                     "startLine": 107,
-                                    "startColumn": 10
+                                    "endLine": 107,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -8344,7 +8938,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 107,
-                                                        "startColumn": 10
+                                                        "endLine": 107,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -8374,7 +8970,9 @@
                                 },
                                 "region": {
                                     "startLine": 107,
-                                    "startColumn": 11
+                                    "endLine": 107,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -8396,7 +8994,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 107,
-                                                        "startColumn": 11
+                                                        "endLine": 107,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -8426,7 +9026,9 @@
                                 },
                                 "region": {
                                     "startLine": 109,
-                                    "startColumn": 15
+                                    "endLine": 109,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -8448,7 +9050,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 109,
-                                                        "startColumn": 15
+                                                        "endLine": 109,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -8478,7 +9082,9 @@
                                 },
                                 "region": {
                                     "startLine": 110,
-                                    "startColumn": 17
+                                    "endLine": 110,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -8500,7 +9106,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 110,
-                                                        "startColumn": 17
+                                                        "endLine": 110,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -8530,7 +9138,9 @@
                                 },
                                 "region": {
                                     "startLine": 118,
-                                    "startColumn": 31
+                                    "endLine": 118,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -8552,7 +9162,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 118,
-                                                        "startColumn": 31
+                                                        "endLine": 118,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -8582,7 +9194,9 @@
                                 },
                                 "region": {
                                     "startLine": 120,
-                                    "startColumn": 18
+                                    "endLine": 120,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8604,7 +9218,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 120,
-                                                        "startColumn": 18
+                                                        "endLine": 120,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8634,7 +9250,9 @@
                                 },
                                 "region": {
                                     "startLine": 124,
-                                    "startColumn": 18
+                                    "endLine": 124,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8656,7 +9274,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 124,
-                                                        "startColumn": 18
+                                                        "endLine": 124,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8686,7 +9306,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 12
+                                    "endLine": 127,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -8708,7 +9330,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 12
+                                                        "endLine": 127,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -8738,7 +9362,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 13
+                                    "endLine": 127,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -8760,7 +9386,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 13
+                                                        "endLine": 127,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -8790,7 +9418,9 @@
                                 },
                                 "region": {
                                     "startLine": 129,
-                                    "startColumn": 15
+                                    "endLine": 129,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -8812,7 +9442,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 129,
-                                                        "startColumn": 15
+                                                        "endLine": 129,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -8842,7 +9474,9 @@
                                 },
                                 "region": {
                                     "startLine": 130,
-                                    "startColumn": 17
+                                    "endLine": 130,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -8864,7 +9498,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 130,
-                                                        "startColumn": 17
+                                                        "endLine": 130,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -8894,7 +9530,9 @@
                                 },
                                 "region": {
                                     "startLine": 137,
-                                    "startColumn": 31
+                                    "endLine": 137,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -8916,7 +9554,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 137,
-                                                        "startColumn": 31
+                                                        "endLine": 137,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -8946,7 +9586,9 @@
                                 },
                                 "region": {
                                     "startLine": 139,
-                                    "startColumn": 18
+                                    "endLine": 139,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -8968,7 +9610,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 139,
-                                                        "startColumn": 18
+                                                        "endLine": 139,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -8998,7 +9642,9 @@
                                 },
                                 "region": {
                                     "startLine": 143,
-                                    "startColumn": 18
+                                    "endLine": 143,
+                                    "startColumn": 18,
+                                    "endColumn": 18
                                 }
                             }
                         }
@@ -9020,7 +9666,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 143,
-                                                        "startColumn": 18
+                                                        "endLine": 143,
+                                                        "startColumn": 18,
+                                                        "endColumn": 18
                                                     }
                                                 },
                                                 "message": {
@@ -9050,7 +9698,9 @@
                                 },
                                 "region": {
                                     "startLine": 147,
-                                    "startColumn": 19
+                                    "endLine": 147,
+                                    "startColumn": 19,
+                                    "endColumn": 19
                                 }
                             }
                         }
@@ -9072,7 +9722,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 147,
-                                                        "startColumn": 19
+                                                        "endLine": 147,
+                                                        "startColumn": 19,
+                                                        "endColumn": 19
                                                     }
                                                 },
                                                 "message": {
@@ -9102,7 +9754,9 @@
                                 },
                                 "region": {
                                     "startLine": 147,
-                                    "startColumn": 28
+                                    "endLine": 147,
+                                    "startColumn": 28,
+                                    "endColumn": 28
                                 }
                             }
                         }
@@ -9124,7 +9778,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 147,
-                                                        "startColumn": 28
+                                                        "endLine": 147,
+                                                        "startColumn": 28,
+                                                        "endColumn": 28
                                                     }
                                                 },
                                                 "message": {
@@ -9154,7 +9810,9 @@
                                 },
                                 "region": {
                                     "startLine": 147,
-                                    "startColumn": 47
+                                    "endLine": 147,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -9176,7 +9834,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 147,
-                                                        "startColumn": 47
+                                                        "endLine": 147,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -9206,7 +9866,9 @@
                                 },
                                 "region": {
                                     "startLine": 148,
-                                    "startColumn": 11
+                                    "endLine": 148,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -9228,7 +9890,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 148,
-                                                        "startColumn": 11
+                                                        "endLine": 148,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -9258,7 +9922,9 @@
                                 },
                                 "region": {
                                     "startLine": 148,
-                                    "startColumn": 12
+                                    "endLine": 148,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -9280,7 +9946,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 148,
-                                                        "startColumn": 12
+                                                        "endLine": 148,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -9310,7 +9978,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 10
+                                    "endLine": 153,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -9332,7 +10002,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 10
+                                                        "endLine": 153,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -9362,7 +10034,9 @@
                                 },
                                 "region": {
                                     "startLine": 153,
-                                    "startColumn": 11
+                                    "endLine": 153,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -9384,7 +10058,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 153,
-                                                        "startColumn": 11
+                                                        "endLine": 153,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -9414,7 +10090,9 @@
                                 },
                                 "region": {
                                     "startLine": 155,
-                                    "startColumn": 17
+                                    "endLine": 155,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -9436,7 +10114,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 155,
-                                                        "startColumn": 17
+                                                        "endLine": 155,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -9466,7 +10146,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 12
+                                    "endLine": 164,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -9488,7 +10170,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 12
+                                                        "endLine": 164,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -9518,7 +10202,9 @@
                                 },
                                 "region": {
                                     "startLine": 164,
-                                    "startColumn": 13
+                                    "endLine": 164,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -9540,7 +10226,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 164,
-                                                        "startColumn": 13
+                                                        "endLine": 164,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -9570,7 +10258,9 @@
                                 },
                                 "region": {
                                     "startLine": 166,
-                                    "startColumn": 17
+                                    "endLine": 166,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -9592,7 +10282,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 166,
-                                                        "startColumn": 17
+                                                        "endLine": 166,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -9622,7 +10314,9 @@
                                 },
                                 "region": {
                                     "startLine": 175,
-                                    "startColumn": 19
+                                    "endLine": 175,
+                                    "startColumn": 19,
+                                    "endColumn": 19
                                 }
                             }
                         }
@@ -9644,7 +10338,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 175,
-                                                        "startColumn": 19
+                                                        "endLine": 175,
+                                                        "startColumn": 19,
+                                                        "endColumn": 19
                                                     }
                                                 },
                                                 "message": {
@@ -9674,7 +10370,9 @@
                                 },
                                 "region": {
                                     "startLine": 175,
-                                    "startColumn": 28
+                                    "endLine": 175,
+                                    "startColumn": 28,
+                                    "endColumn": 28
                                 }
                             }
                         }
@@ -9696,7 +10394,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 175,
-                                                        "startColumn": 28
+                                                        "endLine": 175,
+                                                        "startColumn": 28,
+                                                        "endColumn": 28
                                                     }
                                                 },
                                                 "message": {
@@ -9726,7 +10426,9 @@
                                 },
                                 "region": {
                                     "startLine": 175,
-                                    "startColumn": 47
+                                    "endLine": 175,
+                                    "startColumn": 47,
+                                    "endColumn": 47
                                 }
                             }
                         }
@@ -9748,7 +10450,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 175,
-                                                        "startColumn": 47
+                                                        "endLine": 175,
+                                                        "startColumn": 47,
+                                                        "endColumn": 47
                                                     }
                                                 },
                                                 "message": {
@@ -9778,7 +10482,9 @@
                                 },
                                 "region": {
                                     "startLine": 184,
-                                    "startColumn": 11
+                                    "endLine": 184,
+                                    "startColumn": 11,
+                                    "endColumn": 11
                                 }
                             }
                         }
@@ -9800,7 +10506,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 184,
-                                                        "startColumn": 11
+                                                        "endLine": 184,
+                                                        "startColumn": 11,
+                                                        "endColumn": 11
                                                     }
                                                 },
                                                 "message": {
@@ -9830,7 +10538,9 @@
                                 },
                                 "region": {
                                     "startLine": 184,
-                                    "startColumn": 14
+                                    "endLine": 184,
+                                    "startColumn": 14,
+                                    "endColumn": 14
                                 }
                             }
                         }
@@ -9852,7 +10562,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 184,
-                                                        "startColumn": 14
+                                                        "endLine": 184,
+                                                        "startColumn": 14,
+                                                        "endColumn": 14
                                                     }
                                                 },
                                                 "message": {
@@ -9885,7 +10597,9 @@
                                 },
                                 "region": {
                                     "startLine": 190,
-                                    "startColumn": 1
+                                    "endLine": 190,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -9907,7 +10621,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 190,
-                                                        "startColumn": 1
+                                                        "endLine": 190,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -9937,7 +10653,9 @@
                                 },
                                 "region": {
                                     "startLine": 190,
-                                    "startColumn": 4
+                                    "endLine": 190,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -9959,7 +10677,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 190,
-                                                        "startColumn": 4
+                                                        "endLine": 190,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -9992,7 +10712,9 @@
                                 },
                                 "region": {
                                     "startLine": 199,
-                                    "startColumn": 7
+                                    "endLine": 199,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -10014,7 +10736,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 199,
-                                                        "startColumn": 7
+                                                        "endLine": 199,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -10044,7 +10768,9 @@
                                 },
                                 "region": {
                                     "startLine": 199,
-                                    "startColumn": 7
+                                    "endLine": 199,
+                                    "startColumn": 7,
+                                    "endColumn": 7
                                 }
                             }
                         }
@@ -10066,7 +10792,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 199,
-                                                        "startColumn": 7
+                                                        "endLine": 199,
+                                                        "startColumn": 7,
+                                                        "endColumn": 7
                                                     }
                                                 },
                                                 "message": {
@@ -10096,7 +10824,9 @@
                                 },
                                 "region": {
                                     "startLine": 199,
-                                    "startColumn": 17
+                                    "endLine": 199,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -10118,7 +10848,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 199,
-                                                        "startColumn": 17
+                                                        "endLine": 199,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -10148,7 +10880,9 @@
                                 },
                                 "region": {
                                     "startLine": 31,
-                                    "startColumn": 12
+                                    "endLine": 31,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -10170,7 +10904,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 31,
-                                                        "startColumn": 12
+                                                        "endLine": 31,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -10200,7 +10936,9 @@
                                 },
                                 "region": {
                                     "startLine": 49,
-                                    "startColumn": 6
+                                    "endLine": 49,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -10222,7 +10960,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 49,
-                                                        "startColumn": 6
+                                                        "endLine": 49,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -10252,7 +10992,9 @@
                                 },
                                 "region": {
                                     "startLine": 52,
-                                    "startColumn": 39
+                                    "endLine": 52,
+                                    "startColumn": 39,
+                                    "endColumn": 39
                                 }
                             }
                         }
@@ -10274,7 +11016,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 52,
-                                                        "startColumn": 39
+                                                        "endLine": 52,
+                                                        "startColumn": 39,
+                                                        "endColumn": 39
                                                     }
                                                 },
                                                 "message": {
@@ -10307,7 +11051,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 15
+                                    "endLine": 83,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -10329,7 +11075,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 15
+                                                        "endLine": 83,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -10362,7 +11110,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 31
+                                    "endLine": 83,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -10384,7 +11134,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 31
+                                                        "endLine": 83,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -10417,7 +11169,9 @@
                                 },
                                 "region": {
                                     "startLine": 89,
-                                    "startColumn": 12
+                                    "endLine": 89,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -10439,7 +11193,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 89,
-                                                        "startColumn": 12
+                                                        "endLine": 89,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -10469,7 +11225,9 @@
                                 },
                                 "region": {
                                     "startLine": 99,
-                                    "startColumn": 56
+                                    "endLine": 99,
+                                    "startColumn": 56,
+                                    "endColumn": 56
                                 }
                             }
                         }
@@ -10491,7 +11249,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 99,
-                                                        "startColumn": 56
+                                                        "endLine": 99,
+                                                        "startColumn": 56,
+                                                        "endColumn": 56
                                                     }
                                                 },
                                                 "message": {
@@ -10521,7 +11281,9 @@
                                 },
                                 "region": {
                                     "startLine": 101,
-                                    "startColumn": 59
+                                    "endLine": 101,
+                                    "startColumn": 59,
+                                    "endColumn": 59
                                 }
                             }
                         }
@@ -10543,7 +11305,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 101,
-                                                        "startColumn": 59
+                                                        "endLine": 101,
+                                                        "startColumn": 59,
+                                                        "endColumn": 59
                                                     }
                                                 },
                                                 "message": {
@@ -10576,7 +11340,9 @@
                                 },
                                 "region": {
                                     "startLine": 127,
-                                    "startColumn": 17
+                                    "endLine": 127,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -10598,7 +11364,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 127,
-                                                        "startColumn": 17
+                                                        "endLine": 127,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -10628,7 +11396,9 @@
                                 },
                                 "region": {
                                     "startLine": 132,
-                                    "startColumn": 12
+                                    "endLine": 132,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -10650,7 +11420,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 132,
-                                                        "startColumn": 12
+                                                        "endLine": 132,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -10683,7 +11455,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 37
+                                    "endLine": 75,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -10705,7 +11479,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 37
+                                                        "endLine": 75,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -10735,7 +11511,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 37
+                                    "endLine": 75,
+                                    "startColumn": 37,
+                                    "endColumn": 37
                                 }
                             }
                         }
@@ -10757,7 +11535,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 37
+                                                        "endLine": 75,
+                                                        "startColumn": 37,
+                                                        "endColumn": 37
                                                     }
                                                 },
                                                 "message": {
@@ -10787,7 +11567,9 @@
                                 },
                                 "region": {
                                     "startLine": 75,
-                                    "startColumn": 38
+                                    "endLine": 75,
+                                    "startColumn": 38,
+                                    "endColumn": 38
                                 }
                             }
                         }
@@ -10809,7 +11591,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 75,
-                                                        "startColumn": 38
+                                                        "endLine": 75,
+                                                        "startColumn": 38,
+                                                        "endColumn": 38
                                                     }
                                                 },
                                                 "message": {
@@ -10842,7 +11626,9 @@
                                 },
                                 "region": {
                                     "startLine": 77,
-                                    "startColumn": 38
+                                    "endLine": 77,
+                                    "startColumn": 38,
+                                    "endColumn": 38
                                 }
                             }
                         }
@@ -10864,7 +11650,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 77,
-                                                        "startColumn": 38
+                                                        "endLine": 77,
+                                                        "startColumn": 38,
+                                                        "endColumn": 38
                                                     }
                                                 },
                                                 "message": {
@@ -10894,7 +11682,9 @@
                                 },
                                 "region": {
                                     "startLine": 77,
-                                    "startColumn": 38
+                                    "endLine": 77,
+                                    "startColumn": 38,
+                                    "endColumn": 38
                                 }
                             }
                         }
@@ -10916,7 +11706,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 77,
-                                                        "startColumn": 38
+                                                        "endLine": 77,
+                                                        "startColumn": 38,
+                                                        "endColumn": 38
                                                     }
                                                 },
                                                 "message": {
@@ -10946,7 +11738,9 @@
                                 },
                                 "region": {
                                     "startLine": 77,
-                                    "startColumn": 39
+                                    "endLine": 77,
+                                    "startColumn": 39,
+                                    "endColumn": 39
                                 }
                             }
                         }
@@ -10968,7 +11762,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 77,
-                                                        "startColumn": 39
+                                                        "endLine": 77,
+                                                        "startColumn": 39,
+                                                        "endColumn": 39
                                                     }
                                                 },
                                                 "message": {
@@ -11001,7 +11797,9 @@
                                 },
                                 "region": {
                                     "startLine": 88,
-                                    "startColumn": 30
+                                    "endLine": 88,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11023,7 +11821,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 88,
-                                                        "startColumn": 30
+                                                        "endLine": 88,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11053,7 +11853,9 @@
                                 },
                                 "region": {
                                     "startLine": 88,
-                                    "startColumn": 30
+                                    "endLine": 88,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11075,7 +11877,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 88,
-                                                        "startColumn": 30
+                                                        "endLine": 88,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11105,7 +11909,9 @@
                                 },
                                 "region": {
                                     "startLine": 88,
-                                    "startColumn": 31
+                                    "endLine": 88,
+                                    "startColumn": 31,
+                                    "endColumn": 31
                                 }
                             }
                         }
@@ -11127,7 +11933,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 88,
-                                                        "startColumn": 31
+                                                        "endLine": 88,
+                                                        "startColumn": 31,
+                                                        "endColumn": 31
                                                     }
                                                 },
                                                 "message": {
@@ -11157,7 +11965,9 @@
                                 },
                                 "region": {
                                     "startLine": 99,
-                                    "startColumn": 23
+                                    "endLine": 99,
+                                    "startColumn": 23,
+                                    "endColumn": 23
                                 }
                             }
                         }
@@ -11179,7 +11989,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 99,
-                                                        "startColumn": 23
+                                                        "endLine": 99,
+                                                        "startColumn": 23,
+                                                        "endColumn": 23
                                                     }
                                                 },
                                                 "message": {
@@ -11209,7 +12021,9 @@
                                 },
                                 "region": {
                                     "startLine": 101,
-                                    "startColumn": 30
+                                    "endLine": 101,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11231,7 +12045,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 101,
-                                                        "startColumn": 30
+                                                        "endLine": 101,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11261,7 +12077,9 @@
                                 },
                                 "region": {
                                     "startLine": 104,
-                                    "startColumn": 30
+                                    "endLine": 104,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11283,7 +12101,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 104,
-                                                        "startColumn": 30
+                                                        "endLine": 104,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11313,7 +12133,9 @@
                                 },
                                 "region": {
                                     "startLine": 105,
-                                    "startColumn": 30
+                                    "endLine": 105,
+                                    "startColumn": 30,
+                                    "endColumn": 30
                                 }
                             }
                         }
@@ -11335,7 +12157,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 105,
-                                                        "startColumn": 30
+                                                        "endLine": 105,
+                                                        "startColumn": 30,
+                                                        "endColumn": 30
                                                     }
                                                 },
                                                 "message": {
@@ -11365,7 +12189,9 @@
                                 },
                                 "region": {
                                     "startLine": 35,
-                                    "startColumn": 6
+                                    "endLine": 35,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -11387,7 +12213,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 35,
-                                                        "startColumn": 6
+                                                        "endLine": 35,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -11420,7 +12248,9 @@
                                 },
                                 "region": {
                                     "startLine": 38,
-                                    "startColumn": 4
+                                    "endLine": 38,
+                                    "startColumn": 4,
+                                    "endColumn": 4
                                 }
                             }
                         }
@@ -11442,7 +12272,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 38,
-                                                        "startColumn": 4
+                                                        "endLine": 38,
+                                                        "startColumn": 4,
+                                                        "endColumn": 4
                                                     }
                                                 },
                                                 "message": {
@@ -11475,7 +12307,9 @@
                                 },
                                 "region": {
                                     "startLine": 42,
-                                    "startColumn": 1
+                                    "endLine": 42,
+                                    "startColumn": 1,
+                                    "endColumn": 1
                                 }
                             }
                         }
@@ -11497,7 +12331,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 42,
-                                                        "startColumn": 1
+                                                        "endLine": 42,
+                                                        "startColumn": 1,
+                                                        "endColumn": 1
                                                     }
                                                 },
                                                 "message": {
@@ -11530,7 +12366,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 13
+                                    "endLine": 63,
+                                    "startColumn": 13,
+                                    "endColumn": 13
                                 }
                             }
                         }
@@ -11552,7 +12390,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 13
+                                                        "endLine": 63,
+                                                        "startColumn": 13,
+                                                        "endColumn": 13
                                                     }
                                                 },
                                                 "message": {
@@ -11585,7 +12425,9 @@
                                 },
                                 "region": {
                                     "startLine": 63,
-                                    "startColumn": 34
+                                    "endLine": 63,
+                                    "startColumn": 34,
+                                    "endColumn": 34
                                 }
                             }
                         }
@@ -11607,7 +12449,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 63,
-                                                        "startColumn": 34
+                                                        "endLine": 63,
+                                                        "startColumn": 34,
+                                                        "endColumn": 34
                                                     }
                                                 },
                                                 "message": {
@@ -11640,7 +12484,9 @@
                                 },
                                 "region": {
                                     "startLine": 70,
-                                    "startColumn": 32
+                                    "endLine": 70,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -11662,7 +12508,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 70,
-                                                        "startColumn": 32
+                                                        "endLine": 70,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -11695,7 +12543,9 @@
                                 },
                                 "region": {
                                     "startLine": 70,
-                                    "startColumn": 43
+                                    "endLine": 70,
+                                    "startColumn": 43,
+                                    "endColumn": 43
                                 }
                             }
                         }
@@ -11717,7 +12567,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 70,
-                                                        "startColumn": 43
+                                                        "endLine": 70,
+                                                        "startColumn": 43,
+                                                        "endColumn": 43
                                                     }
                                                 },
                                                 "message": {
@@ -11750,7 +12602,9 @@
                                 },
                                 "region": {
                                     "startLine": 72,
-                                    "startColumn": 32
+                                    "endLine": 72,
+                                    "startColumn": 32,
+                                    "endColumn": 32
                                 }
                             }
                         }
@@ -11772,7 +12626,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 72,
-                                                        "startColumn": 32
+                                                        "endLine": 72,
+                                                        "startColumn": 32,
+                                                        "endColumn": 32
                                                     }
                                                 },
                                                 "message": {
@@ -11805,7 +12661,9 @@
                                 },
                                 "region": {
                                     "startLine": 72,
-                                    "startColumn": 43
+                                    "endLine": 72,
+                                    "startColumn": 43,
+                                    "endColumn": 43
                                 }
                             }
                         }
@@ -11827,7 +12685,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 72,
-                                                        "startColumn": 43
+                                                        "endLine": 72,
+                                                        "startColumn": 43,
+                                                        "endColumn": 43
                                                     }
                                                 },
                                                 "message": {
@@ -11857,7 +12717,9 @@
                                 },
                                 "region": {
                                     "startLine": 79,
-                                    "startColumn": 15
+                                    "endLine": 79,
+                                    "startColumn": 15,
+                                    "endColumn": 15
                                 }
                             }
                         }
@@ -11879,7 +12741,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 79,
-                                                        "startColumn": 15
+                                                        "endLine": 79,
+                                                        "startColumn": 15,
+                                                        "endColumn": 15
                                                     }
                                                 },
                                                 "message": {
@@ -11909,7 +12773,9 @@
                                 },
                                 "region": {
                                     "startLine": 83,
-                                    "startColumn": 45
+                                    "endLine": 83,
+                                    "startColumn": 45,
+                                    "endColumn": 45
                                 }
                             }
                         }
@@ -11931,7 +12797,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 83,
-                                                        "startColumn": 45
+                                                        "endLine": 83,
+                                                        "startColumn": 45,
+                                                        "endColumn": 45
                                                     }
                                                 },
                                                 "message": {
@@ -11964,7 +12832,9 @@
                                 },
                                 "region": {
                                     "startLine": 84,
-                                    "startColumn": 26
+                                    "endLine": 84,
+                                    "startColumn": 26,
+                                    "endColumn": 26
                                 }
                             }
                         }
@@ -11986,7 +12856,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 84,
-                                                        "startColumn": 26
+                                                        "endLine": 84,
+                                                        "startColumn": 26,
+                                                        "endColumn": 26
                                                     }
                                                 },
                                                 "message": {
@@ -12016,7 +12888,9 @@
                                 },
                                 "region": {
                                     "startLine": 31,
-                                    "startColumn": 12
+                                    "endLine": 31,
+                                    "startColumn": 12,
+                                    "endColumn": 12
                                 }
                             }
                         }
@@ -12038,7 +12912,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 31,
-                                                        "startColumn": 12
+                                                        "endLine": 31,
+                                                        "startColumn": 12,
+                                                        "endColumn": 12
                                                     }
                                                 },
                                                 "message": {
@@ -12068,7 +12944,9 @@
                                 },
                                 "region": {
                                     "startLine": 45,
-                                    "startColumn": 6
+                                    "endLine": 45,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -12090,7 +12968,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 45,
-                                                        "startColumn": 6
+                                                        "endLine": 45,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -12120,7 +13000,9 @@
                                 },
                                 "region": {
                                     "startLine": 47,
-                                    "startColumn": 9
+                                    "endLine": 47,
+                                    "startColumn": 9,
+                                    "endColumn": 9
                                 }
                             }
                         }
@@ -12142,7 +13024,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 47,
-                                                        "startColumn": 9
+                                                        "endLine": 47,
+                                                        "startColumn": 9,
+                                                        "endColumn": 9
                                                     }
                                                 },
                                                 "message": {
@@ -12172,7 +13056,9 @@
                                 },
                                 "region": {
                                     "startLine": 56,
-                                    "startColumn": 6
+                                    "endLine": 56,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -12194,7 +13080,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 56,
-                                                        "startColumn": 6
+                                                        "endLine": 56,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {
@@ -12224,7 +13112,9 @@
                                 },
                                 "region": {
                                     "startLine": 61,
-                                    "startColumn": 33
+                                    "endLine": 61,
+                                    "startColumn": 33,
+                                    "endColumn": 33
                                 }
                             }
                         }
@@ -12246,7 +13136,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 61,
-                                                        "startColumn": 33
+                                                        "endLine": 61,
+                                                        "startColumn": 33,
+                                                        "endColumn": 33
                                                     }
                                                 },
                                                 "message": {
@@ -12276,7 +13168,9 @@
                                 },
                                 "region": {
                                     "startLine": 62,
-                                    "startColumn": 10
+                                    "endLine": 62,
+                                    "startColumn": 10,
+                                    "endColumn": 10
                                 }
                             }
                         }
@@ -12298,7 +13192,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 62,
-                                                        "startColumn": 10
+                                                        "endLine": 62,
+                                                        "startColumn": 10,
+                                                        "endColumn": 10
                                                     }
                                                 },
                                                 "message": {
@@ -12328,7 +13224,9 @@
                                 },
                                 "region": {
                                     "startLine": 65,
-                                    "startColumn": 17
+                                    "endLine": 65,
+                                    "startColumn": 17,
+                                    "endColumn": 17
                                 }
                             }
                         }
@@ -12350,7 +13248,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 65,
-                                                        "startColumn": 17
+                                                        "endLine": 65,
+                                                        "startColumn": 17,
+                                                        "endColumn": 17
                                                     }
                                                 },
                                                 "message": {
@@ -12380,7 +13280,9 @@
                                 },
                                 "region": {
                                     "startLine": 65,
-                                    "startColumn": 36
+                                    "endLine": 65,
+                                    "startColumn": 36,
+                                    "endColumn": 36
                                 }
                             }
                         }
@@ -12402,7 +13304,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 65,
-                                                        "startColumn": 36
+                                                        "endLine": 65,
+                                                        "startColumn": 36,
+                                                        "endColumn": 36
                                                     }
                                                 },
                                                 "message": {
@@ -12432,7 +13336,9 @@
                                 },
                                 "region": {
                                     "startLine": 80,
-                                    "startColumn": 6
+                                    "endLine": 80,
+                                    "startColumn": 6,
+                                    "endColumn": 6
                                 }
                             }
                         }
@@ -12454,7 +13360,9 @@
                                                     },
                                                     "region": {
                                                         "startLine": 80,
-                                                        "startColumn": 6
+                                                        "endLine": 80,
+                                                        "startColumn": 6,
+                                                        "endColumn": 6
                                                     }
                                                 },
                                                 "message": {

--- a/tests/csgrep/0114-json-sc-column-stdout.txt
+++ b/tests/csgrep/0114-json-sc-column-stdout.txt
@@ -10,6 +10,7 @@
                     "file_name": "innocent-script.sh",
                     "line": 6,
                     "column": 1,
+                    "h_size": 10,
                     "event": "warning[SC2034]",
                     "message": "UNUSED_VAR appears unused. Verify use (or export if used externally).",
                     "verbosity_level": 0

--- a/tests/csgrep/0120-sarif-parser-semgrep-stdout.txt
+++ b/tests/csgrep/0120-sarif-parser-semgrep-stdout.txt
@@ -12,6 +12,7 @@
                     "file_name": "gzip-1.9/tests/list",
                     "line": 28,
                     "column": 1,
+                    "h_size": 19,
                     "event": "warning[rules.semgrep-rules.bash.lang.best-practice.useless-cat]",
                     "message": "Useless call to 'cat' in a pipeline. Use '<' and '>' for any command to read from a file or write to a file.",
                     "verbosity_level": 0
@@ -27,6 +28,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 95,
                     "column": 5,
+                    "h_size": 43,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -42,6 +44,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 204,
                     "column": 9,
+                    "h_size": 38,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -57,6 +60,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 222,
                     "column": 11,
+                    "h_size": 39,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -72,6 +76,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 227,
                     "column": 5,
+                    "h_size": 28,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -87,6 +92,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 229,
                     "column": 7,
+                    "h_size": 41,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -102,6 +108,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 260,
                     "column": 5,
+                    "h_size": 48,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -117,6 +124,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 262,
                     "column": 5,
+                    "h_size": 32,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -132,6 +140,7 @@
                     "file_name": "gzip-1.9/build-aux/ar-lib",
                     "line": 269,
                     "column": 3,
+                    "h_size": 28,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -147,6 +156,7 @@
                     "file_name": "gzip-1.9/build-aux/compile",
                     "line": 105,
                     "column": 8,
+                    "h_size": 7,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -162,6 +172,7 @@
                     "file_name": "gzip-1.9/build-aux/compile",
                     "line": 228,
                     "column": 3,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -177,6 +188,7 @@
                     "file_name": "gzip-1.9/build-aux/compile",
                     "line": 338,
                     "column": 1,
+                    "h_size": 9,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -192,6 +204,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 141,
                     "column": 2,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -207,6 +220,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 152,
                     "column": 8,
+                    "h_size": 25,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -222,6 +236,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 172,
                     "column": 6,
+                    "h_size": 13,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -237,6 +252,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 173,
                     "column": 6,
+                    "h_size": 17,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -252,6 +268,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 182,
                     "column": 9,
+                    "h_size": 26,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -267,6 +284,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 183,
                     "column": 11,
+                    "h_size": 26,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -282,6 +300,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 195,
                     "column": 3,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -297,6 +316,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 196,
                     "column": 21,
+                    "h_size": 18,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -312,6 +332,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 214,
                     "column": 8,
+                    "h_size": 26,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -327,6 +348,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 227,
                     "column": 12,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -342,6 +364,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 237,
                     "column": 2,
+                    "h_size": 57,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -357,6 +380,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 241,
                     "column": 2,
+                    "h_size": 58,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -372,6 +396,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 245,
                     "column": 2,
+                    "h_size": 61,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -387,6 +412,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 248,
                     "column": 2,
+                    "h_size": 53,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -402,6 +428,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 251,
                     "column": 2,
+                    "h_size": 54,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -417,6 +444,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 254,
                     "column": 2,
+                    "h_size": 43,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -432,6 +460,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 257,
                     "column": 2,
+                    "h_size": 52,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -447,6 +476,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 260,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -462,6 +492,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 313,
                     "column": 2,
+                    "h_size": 134,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -477,6 +508,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 313,
                     "column": 32,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -492,6 +524,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 317,
                     "column": 2,
+                    "h_size": 14,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -507,6 +540,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 331,
                     "column": 2,
+                    "h_size": 37,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -522,6 +556,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 334,
                     "column": 2,
+                    "h_size": 37,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -537,6 +572,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 346,
                     "column": 2,
+                    "h_size": 37,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -552,6 +588,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 373,
                     "column": 2,
+                    "h_size": 76,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -567,6 +604,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 373,
                     "column": 37,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -582,6 +620,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 376,
                     "column": 26,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -597,6 +636,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 379,
                     "column": 26,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -612,6 +652,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 382,
                     "column": 2,
+                    "h_size": 37,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -627,6 +668,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 385,
                     "column": 2,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -642,6 +684,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 392,
                     "column": 4,
+                    "h_size": 28,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -657,6 +700,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 398,
                     "column": 2,
+                    "h_size": 70,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -672,6 +716,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 398,
                     "column": 31,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -687,6 +732,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 404,
                     "column": 26,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -702,6 +748,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 413,
                     "column": 23,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -717,6 +764,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 416,
                     "column": 2,
+                    "h_size": 35,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -732,6 +780,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 423,
                     "column": 3,
+                    "h_size": 35,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -747,6 +796,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 426,
                     "column": 3,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -762,6 +812,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 431,
                     "column": 2,
+                    "h_size": 39,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -777,6 +828,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 442,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -792,6 +844,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 445,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -807,6 +860,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 448,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -822,6 +876,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 451,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -837,6 +892,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 454,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -852,6 +908,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 457,
                     "column": 2,
+                    "h_size": 38,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -867,6 +924,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 460,
                     "column": 2,
+                    "h_size": 39,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -882,6 +940,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 463,
                     "column": 2,
+                    "h_size": 42,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -897,6 +956,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 469,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -912,6 +972,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 472,
                     "column": 2,
+                    "h_size": 35,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -927,6 +988,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 475,
                     "column": 2,
+                    "h_size": 44,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -942,6 +1004,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 478,
                     "column": 2,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -957,6 +1020,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 500,
                     "column": 2,
+                    "h_size": 32,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -972,6 +1036,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 502,
                     "column": 17,
+                    "h_size": 16,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -987,6 +1052,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 504,
                     "column": 2,
+                    "h_size": 37,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1002,6 +1068,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 535,
                     "column": 3,
+                    "h_size": 33,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1017,6 +1084,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 537,
                     "column": 3,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1032,6 +1100,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 540,
                     "column": 6,
+                    "h_size": 33,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1047,6 +1116,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 557,
                     "column": 21,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1062,6 +1132,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 571,
                     "column": 2,
+                    "h_size": 39,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1077,6 +1148,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 575,
                     "column": 3,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1092,6 +1164,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 587,
                     "column": 6,
+                    "h_size": 32,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1107,6 +1180,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 587,
                     "column": 55,
+                    "h_size": 6,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1122,6 +1196,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 601,
                     "column": 5,
+                    "h_size": 34,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1137,6 +1212,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 612,
                     "column": 2,
+                    "h_size": 34,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1152,6 +1228,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 621,
                     "column": 2,
+                    "h_size": 33,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1167,6 +1244,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 636,
                     "column": 12,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1182,6 +1260,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 656,
                     "column": 7,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1197,6 +1276,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 690,
                     "column": 8,
+                    "h_size": 42,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1212,6 +1292,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 690,
                     "column": 76,
+                    "h_size": 6,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1227,6 +1308,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 696,
                     "column": 6,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1242,6 +1324,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 707,
                     "column": 26,
+                    "h_size": 28,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1257,6 +1340,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 715,
                     "column": 2,
+                    "h_size": 34,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1272,6 +1356,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 718,
                     "column": 12,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1287,6 +1372,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 719,
                     "column": 2,
+                    "h_size": 28,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1302,6 +1388,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 722,
                     "column": 2,
+                    "h_size": 22,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1317,6 +1404,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 748,
                     "column": 2,
+                    "h_size": 32,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1332,6 +1420,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 748,
                     "column": 51,
+                    "h_size": 6,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1347,6 +1436,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 769,
                     "column": 6,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1362,6 +1452,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 771,
                     "column": 6,
+                    "h_size": 34,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1377,6 +1468,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 796,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1392,6 +1484,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 799,
                     "column": 2,
+                    "h_size": 49,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1407,6 +1500,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 805,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1422,6 +1516,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 808,
                     "column": 2,
+                    "h_size": 43,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1437,6 +1532,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 811,
                     "column": 2,
+                    "h_size": 36,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1452,6 +1548,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 814,
                     "column": 2,
+                    "h_size": 41,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1467,6 +1564,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 819,
                     "column": 15,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1482,6 +1580,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 824,
                     "column": 15,
+                    "h_size": 21,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0
@@ -1497,6 +1596,7 @@
                     "file_name": "gzip-1.9/build-aux/config.guess",
                     "line": 828,
                     "column": 2,
+                    "h_size": 45,
                     "event": "warning[rules.semgrep-rules.bash.lang.correctness.unquoted-variable-expansion-in-command]",
                     "message": "Variable expansions must be double-quoted so as to prevent being split into multiple pieces according to whitespace or whichever separator is specified by the IFS variable. If you really wish to split the variable's contents, you may use a variable that starts with an underscore e.g. $_X instead of $X, and semgrep will ignore it. If what you need is an array, consider using a proper bash array.",
                     "verbosity_level": 0


### PR DESCRIPTION
Initially csdiff supported only `startLine`/`startColumn`.  Some scanners provide also `endLine`/`endColumn` to denote a region of certain size.

The extra information is stored efficiently in the internal data structure and in csdiff's native JSON format by tracking the diff between `startLine`/`endLine` and `startColumn`/`endColumn`, respectively, and only when the diff is a non-zero (positive) number.

Resolves: https://github.com/csutils/csdiff/issues/136