### PR TITLE
make-srpm.sh: use the pxz compressor if available

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -68,7 +68,13 @@ if [[ "$1" != "--generate-spec" ]]; then
     git archive --prefix="$NV/" --format="tar" HEAD -- . > "$SRC_TAR" \
                                             || die "failed to export sources"
 
-    xz -c "$SRC_TAR" > "$SRC"               || die "failed to compress sources"
+    # use pxz (threaded xz) if available to speed up the compression
+    if pxz --version | grep '^Parallel PXZ' > /dev/null; then
+        XZ=pxz
+    else
+        XZ=xz
+    fi
+    $XZ -c "$SRC_TAR" > "$SRC" || die "failed to compress sources with ${XZ}"
 fi
 
 SPEC="./$PKG.spec"


### PR DESCRIPTION
... to speed up creation of .tar.xz on a multicore machine.  After the recent extension of the test-suite, compression of the distribution tarball started to take too much time.  This change makes it reasonably fast again in my development environment.