### PR TITLE
cstrans-df-run: use std::move() suggested by Coverity

### DIFF
--- a/src/cstrans-df-run.cc
+++ b/src/cstrans-df-run.cc
@@ -195,7 +195,7 @@ void DockerFileTransformer::transformRunLine(std::string *pRunLine)
     }
 
     // return the result of a successful transformation
-    *pRunLine = newRunLine;
+    *pRunLine = std::move(newRunLine);
 }
 
 bool DockerFileTransformer::transform(std::istream &in, std::ostream &out)


### PR DESCRIPTION
Related: https://github.com/csutils/csdiff/pull/190