### PR TITLE
introduce the csdiff-static subpackage

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -90,6 +90,13 @@ cat > "$SPEC" << EOF
 %bcond_without python2
 %endif
 
+# build csdiff-static on RHEL-10+ and Fedora
+%if 0%{?rhel} > 9 || 0%{?fedora}
+%bcond_without static
+%else
+%bcond_with static
+%endif
+
 # python3 support is optional
 %bcond_without python3
 
@@ -134,6 +141,18 @@ This package contains the csdiff tool for comparing code scan defect lists in
 order to find out added or fixed defects, and the csgrep utility for filtering
 defect lists using various filtering predicates.
 
+%if %{with static}
+%package static
+Summary:        Statically linked csgrep-static executable
+BuildRequires:  boost-static
+BuildRequires:  glibc-static
+BuildRequires:  libstdc++-static
+
+%description static
+This pacakge contains a statically linked csgrep-static executable needed
+for context embedding in legacy build environments.
+%endif
+
 %if %{with python2}
 %package -n python2-%{name}
 Summary:        Python interface to csdiff for Python 2
@@ -168,6 +187,7 @@ export BOOST_LIBRARYDIR=/usr/lib64/boost169
 
 make version.cc
 %cmake3                                    \\
+    -DCSGREP_STATIC=%{?with_static:ON}     \\
     -DPYCSDIFF_PYTHON2=%{?with_python2:ON} \\
     -DPYCSDIFF_PYTHON3=%{?with_python3:ON}
 %cmake3_build
@@ -194,6 +214,11 @@ make version.cc
 %{_mandir}/man1/cslinker.1*
 %{_mandir}/man1/cssort.1*
 %{_mandir}/man1/cstrans-df-run.1*
+
+%if %{with static}
+%files static
+%{_libexecdir}/csgrep-static
+%endif
 
 %if %{with python2}
 %files -n python2-%{name}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,22 @@ install(TARGETS
     cstrans-df-run
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# optionally build statically linked csgrep-static
+option(CSGREP_STATIC "Set to ON to build the csgrep-static executable" OFF)
+if(CSGREP_STATIC)
+    add_executable(csgrep-static csgrep.cc)
+    target_link_options(csgrep-static PRIVATE "-static")
+
+    # FIXME: do not hardcode paths to boost static libs
+    target_link_libraries(csgrep-static cs
+        /usr/lib64/libboost_filesystem.a
+        /usr/lib64/libboost_program_options.a
+        /usr/lib64/libboost_regex.a)
+
+    install(TARGETS csgrep-static
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+endif()
+
 # pycsdiff - python binding of csdiff
 option(PYCSDIFF_PYTHON2 "Set to ON to build pycsdiff for Python 2" OFF)
 option(PYCSDIFF_PYTHON3 "Set to ON to build pycsdiff for Python 3" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,25 +55,21 @@ endif()
 add_subdirectory(lib)
 include_directories(lib)
 
-# link cslib.a and boost libraries
-link_libraries(cs
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Boost_REGEX_LIBRARY})
-
 # the list of executables
 add_executable(csdiff       csdiff.cc)
 add_executable(csgrep       csgrep.cc)
 add_executable(cshtml       cshtml.cc)
 add_executable(cslinker     cslinker.cc)
 add_executable(cssort       cssort.cc)
-target_link_libraries(cshtml
-    ${Boost_SYSTEM_LIBRARY})
-
-# experimental
 add_executable(cstrans-df-run cstrans-df-run.cc)
-target_link_libraries(cstrans-df-run
-    ${Boost_SYSTEM_LIBRARY})
+
+# link cslib.a and boost libraries
+foreach(tgt csdiff csgrep cshtml cslinker cssort cstrans-df-run)
+    target_link_libraries(${tgt} cs
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${Boost_REGEX_LIBRARY})
+endforeach()
 
 # declare what 'make install' should install
 include(GNUInstallDirs)
@@ -111,7 +107,10 @@ macro(build_pycsdiff version)
 
     add_library(pycsdiff_py${version} MODULE pycsdiff.cc)
     target_link_libraries(pycsdiff_py${version}
-        PRIVATE ${Boost_PYTHON${PYTHON_VERSION_SUFFIX}_LIBRARY}
+        PRIVATE cs
+                ${Boost_FILESYSTEM_LIBRARY}
+                ${Boost_REGEX_LIBRARY}
+                ${Boost_PYTHON${PYTHON_VERSION_SUFFIX}_LIBRARY}
                 Python${version}::Module)
 
     # set correct name so that `python -c 'import pycsdiff' works`


### PR DESCRIPTION
... with a statically linked csgrep-static executable needed for context embedding in legacy build environments.