### PR TITLE
packaging: build the -static subpkg on 64bit arches only

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -90,8 +90,8 @@ cat > "$SPEC" << EOF
 %bcond_without python2
 %endif
 
-# build csdiff-static on RHEL-10+ and Fedora
-%if 0%{?rhel} > 9 || 0%{?fedora}
+# build csdiff-static on 64bit RHEL-10+ and Fedora
+%if 0%{?__isa_bits} == 64 && (0%{?rhel} > 9 || 0%{?fedora})
 %bcond_without static
 %else
 %bcond_with static


### PR DESCRIPTION
The hard-coded `/usr/lib64` paths to Boost static libraries do not work well in 32bit buildroots and nobody is going to use the -static subpkg on a 32bit architecture anyway.