### PR TITLE
hash-util: make the code work with boost-1.86

### DIFF
--- a/src/lib/hash-util.hh
+++ b/src/lib/hash-util.hh
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include <boost/algorithm/hex.hpp>
-#include <boost/algorithm/string.hpp>
 
 /// compute TEng hash of `src` and return it as hex-encoded string
 template <typename TEng, typename TSrc>
@@ -43,9 +42,6 @@ std::string hexHashStr(const TSrc &src)
 
     // convert the hash to a hex string
     std::string result;
-    boost::algorithm::hex(hash.begin(), hash.end(), back_inserter(result));
-
-    // convert uppercase letters to lowercase
-    boost::algorithm::to_lower(result);
+    boost::algorithm::hex_lower(hash.begin(), hash.end(), back_inserter(result));
     return result;
 }

--- a/src/lib/hash-util.hh
+++ b/src/lib/hash-util.hh
@@ -31,13 +31,15 @@ std::string hexHashStr(const TSrc &src)
     TEng eng;
     eng.process_bytes(src.data(), src.size());
 
-    // export the hash as an array of unsigned int
-    typename TEng::digest_type dst;
+    // export the hash as an array
+    using TDst = typename TEng::digest_type;
+    TDst dst;
     eng.get_digest(dst);
 
-    // convert the hash to a vector of unsigned int
+    // convert the hash to a vector
     static const size_t len = sizeof(dst) / sizeof(dst[0]);
-    const std::vector<unsigned> hash(dst, dst + len);
+    using TElem = typename std::remove_extent<TDst>::type;
+    const std::vector<TElem> hash(dst, dst + len);
 
     // convert the hash to a hex string
     std::string result;


### PR DESCRIPTION
... where `TEng::digest_type` expands to an array of chars rather than an array of ints.  This caused each byte in the resulting hash string to be prepended by 3 zero bytes, which was detected by the CI on macOS:
```
--- /Users/runner/work/csdiff/csdiff/tests/csgrep/0036-csgrep-json-stdout.txt	2024-08-26 16:59:02
+++ -	2024-08-26 17:00:30
@@ -4,7 +4,7 @@
             "checker": "SHELLCHECK_WARNING",
             "language": "shell",
             "tool": "shellcheck",
-            "hash_v1": "b6311c1fdc52c47d4279cd6650af36e6f8299960",
+            "hash_v1": "000000b6000000310000001c0000001f000000dc00000052000000c40000007d0000004200000079000000cd0000006600000050000000af00000036000000e6000000f8000000290000009900000060",
             "key_event_idx": 0,
             "events": [
                 {
```

Also use the `hex_lower` algorithm to optimize out the extra traversal step to lower the output string.
