### PR TITLE
packaging: do not use `%py_provides` for Python 2

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -157,7 +157,7 @@ for context embedding in legacy build environments.
 %package -n python2-%{name}
 Summary:        Python interface to csdiff for Python 2
 BuildRequires:  python2-devel
-%py_provides    python2-%{name}
+%{?python_provide:%python_provide python2-%{name}}
 
 %description -n python2-%{name}
 This package contains the Python 2 binding for the csdiff tool for comparing


### PR DESCRIPTION
The macro is not available in EPEL-7 buildroot and causes the build of csdiff to fail:
```
error: line 79: Unknown tag: %py_provides    python2-csdiff
```

This partially reverts commit df5c63fbbc676220c0c13e3d3e4070beeab0489f.