### PR TITLE
packaging: do not use `%py_provides` in epel-7 builds

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -171,7 +171,12 @@ code scan defect lists to find out added or fixed defects.
 %package -n python3-%{name}
 Summary:        Python interface to csdiff for Python 3
 BuildRequires:  python3-devel
+%if 0%{?rhel} == 7
+# fallback for epel7 buildroots with outdated RPM macros
+%{?python_provide:%python_provide python3-%{name}}
+%else
 %py_provides    python3-%{name}
+%endif
 
 %description -n python3-%{name}
 This package contains the Python 3 binding for the csdiff tool for comparing


### PR DESCRIPTION
If the buildroot contains outdated packages that do not yet contain definition of the macro, it causes the build of csdiff to fail with:
```
error: line 90: Unknown tag: %py_provides    python3-csdiff
```

This reverts commit df5c63fbbc676220c0c13e3d3e4070beeab0489f.

Fixes: commit f16db5adb1c0ccb2619c0e3d11badbc606796ae1
Closes: https://github.com/csutils/csdiff/pull/203