### PR TITLE
parser-json-sarif: initialize the `imp` flag

### DIFF
--- a/src/lib/parser-json-sarif.cc
+++ b/src/lib/parser-json-sarif.cc
@@ -323,8 +323,12 @@ bool SarifTreeDecoder::readNode(Defect *def)
     // initialize the defect structure
     *def = Defect(d->singleChecker);
 
-    // initialize the key event
+    // read "level" if available and propagate "error" to the "imp" flag
     const auto level = valueOf<std::string>(defNode, "level", "warning");
+    if (level == "error")
+        def->imp = 1;
+
+    // initialize the key event
     def->events.push_back(DefEvent(level));
     DefEvent &keyEvent = def->events.back();
 

--- a/tests/csgrep/0106-snyk-prepend-path-stdout.txt
+++ b/tests/csgrep/0106-snyk-prepend-path-stdout.txt
@@ -176,6 +176,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -193,6 +194,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -210,6 +212,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -227,6 +230,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -244,6 +248,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -261,6 +266,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -278,6 +284,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -295,6 +302,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -312,6 +320,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -329,6 +338,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -346,6 +356,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -363,6 +374,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -380,6 +392,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -397,6 +410,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -414,6 +428,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -431,6 +446,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -448,6 +464,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -465,6 +482,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -482,6 +500,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -499,6 +518,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 122,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -771,6 +791,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 1325,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [
@@ -788,6 +809,7 @@
         {
             "checker": "SNYK_CODE_WARNING",
             "cwe": 1325,
+            "imp": 1,
             "tool": "snyk-code",
             "key_event_idx": 0,
             "events": [


### PR DESCRIPTION
... to 1 if `level` is `error`.  This is how `csgrep ---mode=sarif` encodes the `imp` flag.  As a side effect, all findings from Snyk Code with `level` set to `error` will be marked as important.  Nevertheless, this is what `csmock-plugin-snyk` explicitly does already: https://github.com/csutils/csmock/pull/122

Resolves: https://issues.redhat.com/browse/OSH-754
Closes: https://github.com/csutils/csdiff/pull/205