### PR TITLE
csfilter-kfp: record SHA1 hash of HEAD in JSON output

### DIFF
--- a/src/csfilter-kfp
+++ b/src/csfilter-kfp
@@ -53,17 +53,19 @@ def construct_init_cmd(args):
 
 def construct_git_cmd(kfp_git_url):
     # split kfp_git_url into the clone URL and (optional) revision
-    m = re.match("^(.*)#([0-9a-f]+)", kfp_git_url)
+    m = re.match("^(.*)#([0-9a-f]+)$", kfp_git_url)
     if m:
         # checkout a specific revision
         url = shlex.quote(m.group(1))
-        rev = m.group(2)
+        rev = m.group(2)  # no need to quote `rev` because it matches [0-9a-f]+
         return f'git clone {url} ${{td}}/kfp\n' \
-               f'git -C "${{td}}/kfp" reset -q --hard {rev}\n'
+               f'git -C "${{td}}/kfp" reset -q --hard {rev}\n' \
+                'git_url_suffix=\n'
     else:
         # shallow clone of the default branch
         url = shlex.quote(kfp_git_url)
-        return f'git clone --depth 1 {url} "${{td}}/kfp"\n'
+        return f'git clone --depth 1 {url} "${{td}}/kfp"\n' \
+               f'git_url_suffix="#$(git -C "${{td}}/kfp" rev-parse HEAD)"\n'
 
 
 def construct_prep_cmd(args):
@@ -166,7 +168,8 @@ def construct_filter_cmd(args):
         cmd += f' --set-scan-prop=known-false-positives-dir:{kfp_dir}'
     elif args.kfp_git_url:
         kfp_git_url = shlex.quote(args.kfp_git_url)
-        cmd += f' --set-scan-prop=known-false-positives-git-url:{kfp_git_url}'
+        cmd += f' --set-scan-prop=known-false-positives-git-url:{kfp_git_url}' \
+                '${git_url_suffix}'
     cmd += '\n'
 
     return cmd

--- a/tests/csfilter-kfp/0002-stdout.txt
+++ b/tests/csfilter-kfp/0002-stdout.txt
@@ -5,6 +5,7 @@ export td=$(mktemp --directory --tmpdir tmp-csfilter-kfp.XXXXXXXXXX)
 trap "rm -fr '${td}'" EXIT
 set -x
 git clone --depth 1 https://github.com/csutils/kfp.git "${td}/kfp"
+git_url_suffix="#$(git -C "${td}/kfp" rev-parse HEAD)"
 touch "${td}/empty.err"
 (cd "${td}/kfp" && csgrep --mode=json --remove-duplicates ${td}/empty.err */ignore.err */true-positives-ignore.err >"${td}/kfp.json")
 csgrep --mode=json >"${td}/input.json"
@@ -21,4 +22,4 @@ path_filter() {
   fi
 }
 csdiff --show-internal "${td}/kfp.json" "${td}/input.json" | path_filter >${td}/output.json
-csgrep --mode=json "${td}/output.json" --set-scan-prop=known-false-positives-git-url:https://github.com/csutils/kfp.git
+csgrep --mode=json "${td}/output.json" --set-scan-prop=known-false-positives-git-url:https://github.com/csutils/kfp.git${git_url_suffix}

--- a/tests/csfilter-kfp/0003-stdout.txt
+++ b/tests/csfilter-kfp/0003-stdout.txt
@@ -5,6 +5,7 @@ export td=$(mktemp --directory --tmpdir tmp-csfilter-kfp.XXXXXXXXXX)
 trap "rm -fr '${td}'" EXIT
 git clone https://github.com/csutils/kfp.git ${td}/kfp
 git -C "${td}/kfp" reset -q --hard 96408af024db801c3cb6ebda2bff47fe6c45ad09
+git_url_suffix=
 touch "${td}/empty.err"
 (cd "${td}/kfp" && csgrep --mode=json --remove-duplicates ${td}/empty.err */ignore.err */true-positives-ignore.err >"${td}/kfp.json")
 csgrep --mode=json scan-results.json >"${td}/input.json"
@@ -13,4 +14,4 @@ path_filter() {
 }
 csdiff --show-internal "${td}/kfp.json" "${td}/input.json" | path_filter >${td}/output.json
 csdiff "${td}/output.json" "${td}/input.json" >excluded.json
-csgrep --mode=json "${td}/output.json" --set-scan-prop=known-false-positives-git-url:'https://github.com/csutils/kfp.git#96408af024db801c3cb6ebda2bff47fe6c45ad09'
+csgrep --mode=json "${td}/output.json" --set-scan-prop=known-false-positives-git-url:'https://github.com/csutils/kfp.git#96408af024db801c3cb6ebda2bff47fe6c45ad09'${git_url_suffix}


### PR DESCRIPTION
... in case `--kfp-git-url` is used without a pinned revision

Related: https://issues.redhat.com/browse/OSH-737
Closes: https://github.com/csutils/csdiff/pull/207