### PR TITLE
tests/cstrans-df-run: fix the macro that adds a test case

### DIFF
--- a/tests/cstrans-df-run/CMakeLists.txt
+++ b/tests/cstrans-df-run/CMakeLists.txt
@@ -22,7 +22,7 @@ macro(test_cstrans_df_run_core tst opt tag)
     set(cmd "${cmd} ${opt} -- /opt/cov-sa-2019.09/bin/cov-build --dir=/cov --append-log")
     set(cmd "${cmd} <${test_data_prefix}-stdin.txt")
     set(cmd "${cmd} | ${diffcmd} ${test_data_prefix}${tag}-stdout.txt -")
-    add_test_wrap("cstrans-df-run-${tst}" "${cmd}")
+    add_test_wrap("cstrans-df-run-${tst}${tag}" "${cmd}")
 endmacro()
 
 macro(test_cstrans_df_run tst)


### PR DESCRIPTION
... so that tests with/without the `--shell-form` option get assigned distinct test names rather than effectively overwriting each other. This one-line change enables additional 11 tests.

Fixes: commit b05206d17d6a7a3fadd689c6674f805344aafd00
Related: https://github.com/csutils/csdiff/pull/217
Closes: https://github.com/csutils/csdiff/pull/219