### PR TITLE
ci: remove Ubuntu 20.04 jobs

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang++, g++]
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
 
     runs-on: ubuntu-${{ matrix.version }}
     env:


### PR DESCRIPTION
... because these images are deprecated and will be unsupported by April.

Related: https://github.com/actions/runner-images/issues/11101