### PR TITLE
cmake: fix build in `epel7` buildroot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with csdiff.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14.7)
 project(csdiff CXX)
 enable_testing()
 


### PR DESCRIPTION
... where we have `cmake3-3.14.7-1.el7`, which resulted in failure:
```
+ /usr/bin/cmake3 -DCMAKE_C_FLAGS_RELEASE:STRING=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE:STRING=-DNDEBUG -DCMAKE_Fortran_FLAGS_RELEASE:STRING=-DNDEBUG -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr -DINCLUDE_INSTALL_DIR:PATH=/usr/include -DLIB_INSTALL_DIR:PATH=/usr/lib64 -DSYSCONF_INSTALL_DIR:PATH=/etc -DSHARE_INSTALL_PREFIX:PATH=/usr/share -DLIB_SUFFIX=64 -DBUILD_SHARED_LIBS:BOOL=ON -DCSGREP_STATIC= -DPYCSDIFF_PYTHON2=ON -DPYCSDIFF_PYTHON3=ON -DVERSION=csdiff-3.5.4-1.el7_9
CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.

-- Configuring incomplete, errors occurred!

CMake Error at CMakeLists.txt:18 (cmake_minimum_required):
  CMake 3.15 or higher is required.  You are running version 3.14.7

error: Bad exit status from /var/tmp/rpm-tmp.4sggDj (%build)
```